### PR TITLE
docs: add 'Using with claude.ai' section + reference SSE client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ claude mcp add trilium node /path/to/triliumnext-mcp/dist/index.js \
 
 This adds the server at user scope (available across all repositories) in your `~/.claude.json`.
 
+### Using with claude.ai (web/desktop) over SSE
+
+When running in HTTP/SSE mode and connecting from claude.ai (web or desktop), some MCP hosts apply a *deferred tool loading* strategy: only a subset of the server's 35 tools land in the assistant's active context at session start, with the remainder expected to be pulled in on demand. In practice some tools — most often the write-side ones like `create_note`, `update_note_content`, `append_note_content`, `delete_note`, `delete_branch` — may show up in the tool-discovery response with full schemas but then fail when invoked with an error like:
+
+> `<tool_name> has not been loaded yet`
+
+This is a client-side behaviour, not a server issue; the server advertises all tools correctly via `tools/list`. See [#6](https://github.com/perfectra1n/triliumnext-mcp/issues/6) for background.
+
+**Workaround — direct SSE client.** A minimal reference client using only the Python standard library is provided in [`examples/reference-sse-client.py`](examples/reference-sse-client.py). It speaks JSON-RPC over `/sse` + `/message` and can invoke any tool from a shell, which works well as an escape hatch from agents that can shell out:
+
+```bash
+# List all 35 tools
+python3 examples/reference-sse-client.py list
+
+# Call a tool (JSON arguments on stdin)
+echo '{"parentNoteId":"root","title":"Test","type":"text","content":"hi"}' \
+    | python3 examples/reference-sse-client.py call create_note
+
+# Point at a different server
+TRILIUM_MCP_URL=http://other-host:3100 python3 examples/reference-sse-client.py list
+```
+
+Read-side tools (`search_notes`, `get_note_content`, `get_note_attachments`, `create_revision`, etc.) are typically pre-loaded and work natively, so a hybrid pattern tends to be most ergonomic: use native MCP tools for read/snapshot, and the reference client for writes.
+
 ## Configuration
 
 Configuration precedence (highest to lowest):

--- a/examples/reference-sse-client.py
+++ b/examples/reference-sse-client.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Minimal reference MCP client for triliumnext-mcp over the SSE transport.
+
+Uses only the Python standard library. No external dependencies. Works as a
+one-shot CLI for calling any tool exposed by the server.
+
+This exists mainly as a workaround for MCP clients that don't load all tools
+into the assistant's active context (see issue #6) — you can pipe JSON
+arguments via stdin and invoke the tool directly from a shell.
+
+Usage:
+    # List all tools
+    python3 reference-sse-client.py list
+
+    # Call a tool (arguments from stdin)
+    echo '{"parentNoteId":"root","title":"Test","type":"text","content":"hi"}' \
+        | python3 reference-sse-client.py call create_note
+
+    # Point at a different server
+    TRILIUM_MCP_URL=http://other-host:3100 python3 reference-sse-client.py list
+
+The script opens an SSE connection to /sse, reads the endpoint event,
+POSTs JSON-RPC messages to the returned /message?sessionId=... endpoint,
+and waits for the matching response to arrive back over SSE.
+"""
+import os
+import sys
+import json
+import time
+import queue
+import threading
+import urllib.request
+import urllib.error
+
+BASE = os.environ.get("TRILIUM_MCP_URL", "http://localhost:3100")
+
+
+class MCPClient:
+    def __init__(self):
+        self.endpoint = None
+        self.q = queue.Queue()
+        self.running = True
+        self.req_id = 0
+        self.resp = urllib.request.urlopen(
+            urllib.request.Request(BASE + "/sse", headers={"Accept": "text/event-stream"}),
+            timeout=60,
+        )
+        threading.Thread(target=self._reader, daemon=True).start()
+
+    def _reader(self):
+        buf = b""
+        try:
+            while self.running:
+                chunk = self.resp.read1(1024) if hasattr(self.resp, "read1") else self.resp.read(1)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n\n" in buf:
+                    event_bytes, buf = buf.split(b"\n\n", 1)
+                    self._parse(event_bytes.decode("utf-8", "replace"))
+        except Exception as e:
+            self.q.put(("err", str(e)))
+
+    def _parse(self, event):
+        ev = data = None
+        for line in event.split("\n"):
+            if line.startswith("event:"):
+                ev = line[6:].strip()
+            elif line.startswith("data:"):
+                data = line[5:].strip()
+        if ev == "endpoint" and data:
+            self.endpoint = BASE + data
+            self.q.put(("endpoint", data))
+        elif ev == "message" and data:
+            try:
+                self.q.put(("message", json.loads(data)))
+            except Exception:
+                self.q.put(("raw", data))
+
+    def wait_endpoint(self, timeout=5):
+        t0 = time.time()
+        while time.time() - t0 < timeout:
+            try:
+                k, _ = self.q.get(timeout=0.1)
+                if k == "endpoint":
+                    return True
+            except queue.Empty:
+                pass
+        return False
+
+    def send(self, method, params):
+        self.req_id += 1
+        rid = self.req_id
+        body = json.dumps({"jsonrpc": "2.0", "id": rid, "method": method, "params": params}).encode()
+        try:
+            with urllib.request.urlopen(
+                urllib.request.Request(
+                    self.endpoint, data=body,
+                    headers={"Content-Type": "application/json"}, method="POST"),
+                timeout=30) as r:
+                r.read()
+        except urllib.error.HTTPError as e:
+            return {"error": f"HTTP {e.code}: {e.read().decode()[:500]}"}
+        t0 = time.time()
+        while time.time() - t0 < 30:
+            try:
+                k, d = self.q.get(timeout=0.5)
+                if k == "message" and isinstance(d, dict) and d.get("id") == rid:
+                    return d
+            except queue.Empty:
+                pass
+        return {"error": "timeout"}
+
+    def notify(self, method, params):
+        body = json.dumps({"jsonrpc": "2.0", "method": method, "params": params}).encode()
+        with urllib.request.urlopen(
+            urllib.request.Request(
+                self.endpoint, data=body,
+                headers={"Content-Type": "application/json"}, method="POST"),
+            timeout=10) as r:
+            r.read()
+
+
+def main():
+    c = MCPClient()
+    if not c.wait_endpoint():
+        print("ERROR: no endpoint received from /sse", file=sys.stderr)
+        sys.exit(1)
+
+    init = c.send("initialize", {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "reference-sse-client", "version": "1.0"},
+    })
+    if "result" not in init:
+        print(f"initialize failed: {init}", file=sys.stderr)
+        sys.exit(1)
+    c.notify("notifications/initialized", {})
+    time.sleep(0.2)
+
+    action = sys.argv[1] if len(sys.argv) > 1 else "list"
+    if action == "list":
+        r = c.send("tools/list", {})
+        tools = r.get("result", {}).get("tools", [])
+        print(f"{len(tools)} tools available:")
+        for t in tools:
+            print(f"  {t['name']}")
+    elif action == "call":
+        if len(sys.argv) < 3:
+            print("usage: call <tool_name>  (arguments on stdin as JSON)", file=sys.stderr)
+            sys.exit(1)
+        args = json.loads(sys.stdin.read())
+        r = c.send("tools/call", {"name": sys.argv[2], "arguments": args})
+        print(json.dumps(r, indent=2))
+    else:
+        print(f"unknown action: {action} (use 'list' or 'call')", file=sys.stderr)
+        sys.exit(1)
+
+    c.running = False
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #6. Adds a small docs section + a reference SSE client so that users hitting the claude.ai "has not been loaded yet" quirk can find the workaround from the README instead of debugging from scratch.

### Changes

- **README.md** — new subsection `Using with claude.ai (web/desktop) over SSE` placed under the existing `Adding to Claude Code` section. Briefly explains the deferred-tool-loading behaviour, clarifies it's client-side (not a server bug), and points at the reference client.
- **examples/reference-sse-client.py** — minimal Python-stdlib-only MCP client. Opens `/sse`, reads the endpoint event, POSTs JSON-RPC messages to `/message?sessionId=…`, correlates responses by id. Supports `list` and `call <tool>` with JSON arguments on stdin. Honours `TRILIUM_MCP_URL` env var.

### Why these changes

I used this server extensively from claude.ai recently and hit the issue with `create_note`, `update_note_content`, etc. — the server advertises all 35 tools correctly via `tools/list`, but the client didn't load them all. The reference client was enough of an escape hatch that I could drive all write operations through it via `shell_exec`, end-to-end-tested against commit `aa1f218`. Figured it's worth upstreaming so others don't have to rebuild it.

### Testing

- `python3 examples/reference-sse-client.py list` lists all 35 tools
- `create_note` via the client succeeds with `type=text`, `type=mermaid`, `type=image` (base64), and `type=text` + `images` array with `image:N` placeholders
- No dependencies beyond the Python standard library

### Notes

- Happy to shorten the README section if it feels too long for a docs change
- The example file is executable (`chmod +x`) with a shebang — can strip that if you'd prefer it as a plain reference
- No code changes in `src/`, only docs + example
