### PR TITLE
feat(search): graceful fuzzy fallback for search_notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,8 +417,51 @@ The note-mutating tools (`create_note`, `write_note`, `organize_note` move/clone
 
 | Tool | Description |
 |------|-------------|
-| `search_notes` | Full-text and attribute search with filters, ordering, and limits. |
+| `search_notes` | Full-text and attribute search with filters, ordering, and limits. Plain-fulltext queries that return zero results are automatically retried as a relevance-ranked OR over the individual terms — see [Graceful fuzzy fallback](#graceful-fuzzy-fallback) below. |
 | `get_note_tree` | Get children of a note for tree navigation. |
+
+#### Graceful fuzzy fallback
+
+Trilium ANDs fulltext terms, so `体积云 Niagara 教程` returns **nothing** if any single term is
+wrong — and zero results tell the caller nothing about which term was the bad one. `search_notes`
+therefore retries such queries automatically.
+
+`fuzzy` controls this:
+
+| Value | Behavior |
+|-------|----------|
+| `auto` (default) | Run the query as written. If it returns **zero** results and the query is eligible, retry it as an OR over the individual terms, ranked by relevance. |
+| `off` | Never retry. Strict Trilium semantics, byte-identical to the pre-fallback response. |
+| `force` | Skip the exact attempt and go straight to the ranked OR search. |
+
+A query is **eligible** only if it is plain fulltext with two or more terms. Attribute filters
+(`#project`), property expressions (`note.title *=* x`), `id:`/`title:` prefixes, and queries that
+already contain `or` are never retried — OR-expanding them would change what was asked, not widen it.
+Terms are capped at 8, since each becomes an unindexed substring scan.
+
+When the fallback fires, the response gains sibling fields alongside the usual `results` (the note
+objects themselves are never modified):
+
+```jsonc
+{
+  "results": [ /* ...unmodified notes, most relevant first... */ ],
+  "searchMode": "fuzzy",
+  "fuzzyTerms": ["体积云", "Niagara", "教程"],
+  "totalCandidates": 12,
+  "termsMatchedInTitleOrAttributes": { "体积云": 12, "Niagara": 0, "教程": 9 },
+  "note": "..."
+}
+```
+
+`termsMatchedInTitleOrAttributes` is the "which term was wrong?" signal — a `0` means that term
+appeared in no returned note's title or attributes, so it is the one to drop and re-query without.
+
+**Ranking is title- and attribute-only.** Trilium's ETAPI search response carries no note content,
+so scoring content would cost one extra HTTP request per candidate. A note that matched only in its
+body is therefore still returned — never filtered out — but scores zero and ranks last. Check
+`totalCandidates` against `results.length` to see whether you are looking at a truncated view.
+If `orderBy` is set it is honored: the OR query still widens recall, but results keep your ordering
+rather than being re-ranked.
 
 ### Organization (1 tool)
 
@@ -478,7 +521,7 @@ The tool surface was consolidated in a breaking release. The mapping from the ol
 | `undelete_note` | `delete_note` with `action="undelete"` |
 | `get_note_attachments` | `get_attachment` with `noteId` (list form) |
 | `get_note_history` | `get_note_history` (unchanged) |
-| `search_notes` | `search_notes` (unchanged) |
+| `search_notes` | `search_notes` (unchanged; gained an optional `fuzzy` fallback) |
 | `get_note_tree` | `get_note_tree` (unchanged) |
 | `move_note` | `organize_note` with `action="move"` |
 | `clone_note` | `organize_note` with `action="clone"` |

--- a/src/tools/fuzzySearch.ts
+++ b/src/tools/fuzzySearch.ts
@@ -1,0 +1,288 @@
+/**
+ * High-recall fallback for `search_notes`.
+ *
+ * Trilium's fulltext search is implicit-AND, so a query where a single term is
+ * wrong returns nothing at all — the worst outcome for a caller working from
+ * partial recall, because zero results carry no signal about which term was bad.
+ *
+ * This module turns such a query into an OR over its individual terms and ranks
+ * the results client-side. Ranking is necessarily title- and attribute-only:
+ * ETAPI's search response carries no note content (see `SearchResponse` in
+ * types/etapi.ts), and fetching it would cost one HTTP request per candidate.
+ *
+ * The consequence is important enough to state plainly: a note that matched only
+ * in its body scores zero here. It is still returned — ranked low, but never
+ * dropped — because Trilium already decided it matched. `rankNotes` sorts; it
+ * never filters.
+ */
+
+import type { Note } from '../types/etapi.js';
+import { isBareFulltextSegment, isOrOperator, tokenize } from './queryPreprocessor.js';
+
+/**
+ * Upper bound on terms fed into the OR query. Each term becomes two arms
+ * (`note.content` and `note.title`), and `note.content *=*` is an unindexed
+ * substring scan — so an uncapped query built from a pasted paragraph would be
+ * pathologically expensive.
+ */
+export const MAX_FUZZY_TERMS = 8;
+
+/** Candidates fetched per result returned, so there is something to rank. */
+export const FUZZY_RECALL_MULTIPLIER = 4;
+
+/** Baseline ceiling on the recall window; never clamps below the caller's own limit. */
+export const FUZZY_RECALL_CAP = 200;
+
+/** Results returned when the caller expressed no preference. */
+export const DEFAULT_FUZZY_RESULT_LIMIT = 50;
+
+/** Matches `searchLimitSchema.max` in validators.ts. */
+const SEARCH_LIMIT_CEILING = 10000;
+
+export type FuzzyMode = 'auto' | 'off' | 'force';
+
+export interface RankedNote {
+  note: Note;
+  score: number;
+  matchedTerms: string[];
+}
+
+/**
+ * Characters that imply structured Trilium query syntax rather than plain fulltext.
+ *
+ * This is deliberately stricter than `isBareFulltextSegment`, which only inspects
+ * token prefixes and so misses e.g. a trailing `)`. Being strictly stricter means
+ * that gap cannot leak into the fuzzy path and produce a malformed query.
+ */
+const STRUCTURED_SYNTAX_RE = /[#~()=<>*]/;
+
+/**
+ * Scripts where a single character is a meaningful morpheme, so the ASCII
+ * minimum-length rule must not apply. Covers Hiragana, Katakana, CJK Ext-A,
+ * CJK Unified, CJK Compatibility Ideographs, halfwidth Katakana, Hangul, and
+ * CJK Ext-B and beyond.
+ */
+const CJK_RE =
+  /[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ가-힯]|[\u{20000}-\u{2fa1f}]/u;
+
+/** Punctuation stripped from the edges of a bare token, ASCII and CJK alike. */
+const EDGE_PUNCTUATION_RE = /^[\s,.;:!?'"、。！？，；：「」『』（）]+|[\s,.;:!?'"、。！？，；：「」『』（）]+$/gu;
+
+/**
+ * Normalize for comparison only. NFKC folds full-width forms onto their ASCII
+ * equivalents so `Ｎｉａｇａｒａ` matches `niagara`.
+ *
+ * Note this is asymmetric with Trilium, which matched on raw text. That is
+ * acceptable — ranking is a heuristic, and Trilium's matching is not ours to
+ * change — but it does mean our notion of "matched" is slightly broader than
+ * the one that produced the candidate set.
+ */
+function normalize(value: string): string {
+  return value.normalize('NFKC').toLowerCase();
+}
+
+function containsCjk(term: string): boolean {
+  return CJK_RE.test(term);
+}
+
+/**
+ * Split a free-form query into distinct search terms.
+ *
+ * Quoted phrases survive as single terms regardless of length — an explicitly
+ * quoted phrase is user intent, and the minimum-length rule must not override it.
+ */
+export function extractFuzzyTerms(query: string): string[] {
+  const terms: string[] = [];
+  const seen = new Set<string>();
+
+  for (const token of tokenize(query)) {
+    if (isOrOperator(token)) continue;
+
+    let term: string;
+    if (token.length >= 2 && token.startsWith('"') && token.endsWith('"')) {
+      // Strip the outer quotes, then unwind the `\\` / `\"` escape grammar
+      // that tokenize() accepts.
+      term = token.slice(1, -1).replace(/\\(.)/g, '$1').trim();
+    } else {
+      term = token.replace(EDGE_PUNCTUATION_RE, '');
+      // A single ASCII character is a substring of nearly every note and would
+      // drown the signal; a single CJK character is a real morpheme.
+      if (term.length < 2 && !containsCjk(term)) continue;
+    }
+
+    if (term.length === 0) continue;
+
+    // Deduplicate with toLowerCase, not toLocaleLowerCase — the latter is
+    // locale-dependent (Turkish dotless i) and would make results vary by host.
+    const key = term.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    terms.push(term);
+
+    if (terms.length === MAX_FUZZY_TERMS) break;
+  }
+
+  return terms;
+}
+
+/**
+ * Whether a query may be retried as a ranked OR search.
+ *
+ * Evaluated against the ORIGINAL user query, never the preprocessed one:
+ * preprocessing may already have rewritten `title:x` into `note.title *=* x`,
+ * which would then look ineligible for the wrong reason.
+ */
+export function isFuzzyEligible(query: string, mode: FuzzyMode): boolean {
+  if (mode === 'off') return false;
+
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return false;
+
+  // Structured syntax: attribute filters, property expressions, operators,
+  // grouping. OR-expanding these produces a different and probably invalid query.
+  if (STRUCTURED_SYNTAX_RE.test(query)) return false;
+  if (!isBareFulltextSegment(tokens)) return false;
+
+  // Already maximum-recall — zero results means genuinely nothing.
+  if (tokens.some(isOrOperator)) return false;
+
+  // Explicit scoping. Widening what the caller deliberately narrowed would be
+  // the opposite of helpful.
+  const first = tokens[0].toLowerCase();
+  if (first.startsWith('title:') || first.startsWith('id:')) return false;
+
+  // With one term the OR query has a single arm, making the retry a duplicate of
+  // the search that just failed. `force` is an explicit request, so it may proceed.
+  const minimumTerms = mode === 'force' ? 1 : 2;
+  return extractFuzzyTerms(query).length >= minimumTerms;
+}
+
+/**
+ * Quote a term for embedding in a Trilium query.
+ *
+ * Always quotes, with no "only if it contains a space" branch — one code path is
+ * one thing to get right. Backslashes are escaped before quotes, otherwise the
+ * second replace would double-escape what the first just introduced.
+ */
+export function quoteTerm(term: string): string {
+  return `"${term.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Build the high-recall OR query.
+ *
+ * Both `note.content` and `note.title` arms are emitted per term. Trilium's
+ * content does not include the title, and the motivating case — a half-remembered
+ * note — is overwhelmingly a half-remembered title. The title arms also keep the
+ * candidate set aligned with what the ranker can actually score.
+ */
+export function buildFuzzyQuery(terms: string[]): string {
+  return terms
+    .flatMap((term) => {
+      const quoted = quoteTerm(term);
+      return [`note.content *=* ${quoted}`, `note.title *=* ${quoted}`];
+    })
+    .join(' OR ');
+}
+
+function attributeMatches(note: Note, normalizedTerm: string): boolean {
+  for (const attr of note.attributes ?? []) {
+    if (
+      normalize(attr.name ?? '').includes(normalizedTerm) ||
+      normalize(attr.value ?? '').includes(normalizedTerm)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Order candidates by how much title/attribute evidence they show for the terms.
+ *
+ * This is a sort, never a filter: the returned array always has the same length
+ * as the input. A score of zero does not mean the note is a bad match — it means
+ * this function, which cannot see note content, has no evidence either way.
+ */
+export function rankNotes(notes: Note[], terms: string[]): RankedNote[] {
+  const normalizedTerms = terms.map((term) => ({ raw: term, norm: normalize(term) }));
+  const normalizedQuery = normalizedTerms.map((t) => t.norm).join(' ');
+
+  const ranked: RankedNote[] = notes.map((note) => {
+    const title = normalize(note.title ?? '');
+    const matchedTerms: string[] = [];
+    let score = 0;
+    let titleHits = 0;
+    let startsWithTerm = false;
+
+    for (const { raw, norm } of normalizedTerms) {
+      let matched = false;
+
+      if (norm.length > 0 && title.includes(norm)) {
+        score += 10;
+        titleHits += 1;
+        matched = true;
+        if (title.startsWith(norm)) startsWithTerm = true;
+      }
+
+      // Any label or relation, matched on name or value — not just labels
+      // literally named "tag".
+      if (norm.length > 0 && attributeMatches(note, norm)) {
+        score += 4;
+        matched = true;
+      }
+
+      if (matched) matchedTerms.push(raw);
+    }
+
+    // Approximates the AND the caller originally asked for: a note carrying every
+    // term in its title is almost certainly the one they meant.
+    if (normalizedTerms.length > 0 && titleHits === normalizedTerms.length) score += 15;
+
+    if (normalizedTerms.length > 0) {
+      score += Math.round((20 * matchedTerms.length) / normalizedTerms.length);
+    }
+
+    if (startsWithTerm) score += 3;
+    if (title.length > 0 && (title === normalizedQuery || normalizedTerms.some((t) => t.norm === title))) {
+      score += 5;
+    }
+
+    return { note, score, matchedTerms };
+  });
+
+  return ranked.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.matchedTerms.length !== a.matchedTerms.length) {
+      return b.matchedTerms.length - a.matchedTerms.length;
+    }
+    // A shorter title that still matches is the more specific hit.
+    const aLen = (a.note.title ?? '').length;
+    const bLen = (b.note.title ?? '').length;
+    if (aLen !== bLen) return aLen - bLen;
+    const aMod = a.note.utcDateModified ?? '';
+    const bMod = b.note.utcDateModified ?? '';
+    if (aMod !== bMod) return bMod.localeCompare(aMod);
+    // Mandatory final tie-break: Array.sort is stable, so without a total ordering
+    // the caller's input order would leak into the output and this would not be a
+    // pure function of the input set.
+    return (a.note.noteId ?? '').localeCompare(b.note.noteId ?? '');
+  });
+}
+
+/**
+ * Decide how many candidates to fetch and how many to return.
+ *
+ * Over-fetching is what makes ranking meaningful — you cannot rank ten results
+ * into a better ten. The `Math.max(..., sliceTo)` guards ensure a caller asking
+ * for more than the baseline cap is never silently short-changed.
+ */
+export function resolveFuzzyLimit(callerLimit?: number): { fetchLimit: number; sliceTo: number } {
+  const sliceTo = callerLimit ?? DEFAULT_FUZZY_RESULT_LIMIT;
+  const fetchLimit = Math.min(
+    Math.max(sliceTo * FUZZY_RECALL_MULTIPLIER, sliceTo),
+    Math.max(FUZZY_RECALL_CAP, sliceTo),
+    SEARCH_LIMIT_CEILING
+  );
+  return { fetchLimit, sliceTo };
+}

--- a/src/tools/queryPreprocessor.ts
+++ b/src/tools/queryPreprocessor.ts
@@ -16,8 +16,12 @@ export interface PreprocessedQuery {
 
 /**
  * Tokenize a query string, keeping quoted phrases as single tokens.
+ *
+ * The escape grammar is `\\` and `\"` inside a quoted phrase; anything emitting
+ * quoted terms back into a Trilium query must escape to match (see
+ * `quoteTerm` in fuzzySearch.ts).
  */
-function tokenize(query: string): string[] {
+export function tokenize(query: string): string[] {
   const tokens: string[] = [];
   const regex = /"(?:[^"\\]|\\.)*"|\S+/g;
   let match;
@@ -30,15 +34,20 @@ function tokenize(query: string): string[] {
 /**
  * Check if a token is an OR operator (case-insensitive).
  */
-function isOrOperator(token: string): boolean {
+export function isOrOperator(token: string): boolean {
   return token.toLowerCase() === 'or';
 }
 
 /**
  * Check if a list of tokens represents a bare fulltext segment
  * (no attribute syntax, no property expressions, no comparison operators).
+ *
+ * This is a heuristic tuned for query *rewriting*, not a validator. It is
+ * deliberately asymmetric — it checks `startsWith(')')`, so it catches `)foo`
+ * but not `foo)`. Callers using it as a safety gate must add their own stricter
+ * check rather than assume it is exhaustive.
  */
-function isBareFulltextSegment(tokens: string[]): boolean {
+export function isBareFulltextSegment(tokens: string[]): boolean {
   return tokens.every((token) => {
     if (token.startsWith('#') || token.startsWith('~')) return false;
     if (token.startsWith('note.')) return false;

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -29,10 +29,16 @@ export function defineTool(
   schema: z.ZodObject<z.ZodRawShape>,
   annotations?: ToolAnnotations
 ): Tool {
-  const jsonSchema = schema.toJSONSchema({ unrepresentable: 'any', reused: 'inline' }) as Record<
-    string,
-    unknown
-  >;
+  // `io: 'input'` is required, not cosmetic. Zod's toJSONSchema() defaults to OUTPUT
+  // semantics, under which a `.default()` field is always present and therefore lands
+  // in `required`. An MCP inputSchema describes what the caller SENDS, so it must be
+  // the input side — otherwise every defaulted parameter is advertised to clients as
+  // mandatory, and the `default` keyword is omitted entirely.
+  const jsonSchema = schema.toJSONSchema({
+    unrepresentable: 'any',
+    reused: 'inline',
+    io: 'input',
+  }) as Record<string, unknown>;
 
   delete jsonSchema.$schema;
   delete jsonSchema.additionalProperties;

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -5,6 +5,14 @@ import { TriliumClientError } from '../client/trilium.js';
 import { defineTool } from './schemas.js';
 import { orderDirectionSchema, searchLimitSchema } from './validators.js';
 import { preprocessSearchQuery } from './queryPreprocessor.js';
+import {
+  buildFuzzyQuery,
+  extractFuzzyTerms,
+  isFuzzyEligible,
+  rankNotes,
+  resolveFuzzyLimit,
+  type FuzzyMode,
+} from './fuzzySearch.js';
 
 const searchNotesSchema = z.object({
   query: z
@@ -26,6 +34,17 @@ const searchNotesSchema = z.object({
     .describe('Property to order by (title, dateCreated, dateModified)'),
   orderDirection: orderDirectionSchema.optional().describe('Order direction'),
   limit: searchLimitSchema.optional().describe('Maximum number of results'),
+  fuzzy: z
+    .enum(['auto', 'off', 'force'])
+    .optional()
+    .default('auto')
+    .describe(
+      'Fallback behavior when the query finds nothing. "auto" (default): if the exact query returns ZERO ' +
+        'results and the query is plain fulltext with 2+ terms, retry it as an OR over the individual terms, ' +
+        'ranked by title/attribute relevance — the response then carries searchMode:"fuzzy" and fuzzyTerms. ' +
+        '"off": never retry; exact Trilium semantics only. "force": go straight to the ranked OR search. ' +
+        'Never applies to attribute (#label), property (note.*), id:/title:-prefixed, or already-OR queries.'
+    ),
 });
 
 const getNoteTreeSchema = z.object({
@@ -81,7 +100,17 @@ export function registerSearchTools(): Tool[] {
 - \`#type = task #priority = high\` - Multiple label conditions (implicit AND)
 - \`meeting or project\` - Notes containing "meeting" OR "project"
 - \`id:abc123def\` - Direct lookup of note by ID
-- \`title:weekly meeting\` - Notes with "weekly meeting" in title`,
+- \`title:weekly meeting\` - Notes with "weekly meeting" in title
+
+**Graceful fallback (\`fuzzy\`):**
+Trilium ANDs fulltext terms, so one wrong term returns nothing. By default (\`fuzzy: "auto"\`),
+a plain-fulltext query with 2+ terms that returns ZERO results is automatically retried as an
+OR over the individual terms, ranked by relevance. The response then adds \`searchMode: "fuzzy"\`,
+\`fuzzyTerms\`, \`totalCandidates\`, and \`termsMatchedInTitleOrAttributes\` — use that last one to
+spot which term is failing and re-query without it. Ranking uses titles and attributes only, so
+a note matching only in its body is still returned but ranks low: scan past the first result.
+Set \`fuzzy: "off"\` for strict Trilium semantics, or \`"force"\` to skip the exact attempt.
+Never applies to \`#label\`, \`note.*\`, \`id:\`/\`title:\`, or already-OR queries.`,
       searchNotesSchema,
       { title: 'Search notes', readOnlyHint: true, openWorldHint: false }
     ),
@@ -94,6 +123,143 @@ export function registerSearchTools(): Tool[] {
       { title: 'Get note tree', readOnlyHint: true }
     ),
   ];
+}
+
+type SearchArgs = z.infer<typeof searchNotesSchema>;
+
+/** Scope and shaping options shared by the exact search and its fuzzy retry. */
+function scopeParams(parsed: SearchArgs) {
+  return {
+    fastSearch: parsed.fastSearch,
+    includeArchivedNotes: parsed.includeArchivedNotes,
+    ancestorNoteId: parsed.ancestorNoteId,
+    orderBy: parsed.orderBy,
+    orderDirection: parsed.orderDirection,
+  };
+}
+
+/**
+ * Explain the rewrite to the caller. This is not decoration: the model needs to know
+ * the results are approximate, that relevance is title-only so the right note may not
+ * be first, and what a zero in the per-term counts actually means.
+ */
+function describeFuzzyRun(args: {
+  terms: string[];
+  returned: number;
+  totalCandidates: number;
+  reranked: boolean;
+  forced: boolean;
+}): string {
+  const { terms, returned, totalCandidates, reranked, forced } = args;
+  const termList = `${terms.length} term(s): ${terms.join(', ')}`;
+  return [
+    // Under fuzzy="force" no exact search was ever run, so claiming one failed
+    // would be a lie the caller has no way to check.
+    forced
+      ? `Ran directly as an OR search over ${termList}, as requested by fuzzy="force".`
+      : `No notes matched all terms. Retried as an OR search over ${termList}.`,
+    reranked
+      ? 'Results are ranked by title and attribute relevance.'
+      : 'Results keep the ordering you requested via orderBy rather than being re-ranked by relevance.',
+    `Showing ${returned} of ${totalCandidates} candidates.`,
+    'Relevance is computed from titles and attributes only — Trilium\'s search response carries no note ' +
+      'content — so a note matching only in its body still appears, ranked low. Scan past the first result.',
+    'In termsMatchedInTitleOrAttributes, a 0 means the term was absent from these results\' titles and ' +
+      'attributes, not that it is absent from the notes.',
+    'Pass fuzzy="off" to disable this fallback.',
+  ].join(' ');
+}
+
+async function runFuzzySearch(
+  client: TriliumClient,
+  parsed: SearchArgs,
+  terms: string[],
+  forced: boolean
+): Promise<Record<string, unknown>> {
+  const { fetchLimit, sliceTo } = resolveFuzzyLimit(parsed.limit);
+  const response = await client.searchNotes({
+    ...scopeParams(parsed),
+    search: buildFuzzyQuery(terms),
+    limit: fetchLimit,
+  });
+
+  const ranked = rankNotes(response.results, terms);
+  // An explicit orderBy is an instruction, not a preference — honor it and take only
+  // the recall win. Ranking is still computed, for the per-term evidence counts.
+  const reranked = !parsed.orderBy;
+  const ordered = reranked ? ranked.map((r) => r.note) : response.results;
+
+  const termsMatchedInTitleOrAttributes = Object.fromEntries(
+    terms.map((term) => [term, ranked.filter((r) => r.matchedTerms.includes(term)).length])
+  );
+
+  return {
+    results: ordered.slice(0, sliceTo),
+    searchMode: 'fuzzy',
+    fuzzyTerms: terms,
+    totalCandidates: response.results.length,
+    termsMatchedInTitleOrAttributes,
+    note: describeFuzzyRun({
+      terms,
+      returned: Math.min(ordered.length, sliceTo),
+      totalCandidates: response.results.length,
+      reranked,
+      forced,
+    }),
+    ...(response.debugInfo ? { debugInfo: response.debugInfo } : {}),
+  };
+}
+
+/**
+ * Run the search, retrying as a ranked OR when the exact query comes back empty.
+ *
+ * Both call sites route through here so the parameter list cannot drift between the
+ * normal path and the noteId-404 path. `allowFuzzy` is false on the latter: a caller
+ * who asked for a specific ID does not want an OR-expansion of that ID.
+ */
+async function runSearchWithFallback(
+  client: TriliumClient,
+  parsed: SearchArgs,
+  effectiveQuery: string,
+  originalQuery: string,
+  allowFuzzy: boolean
+): Promise<Record<string, unknown>> {
+  const mode: FuzzyMode = parsed.fuzzy ?? 'auto';
+  const eligible = allowFuzzy && isFuzzyEligible(originalQuery, mode);
+
+  if (mode === 'force' && eligible) {
+    return runFuzzySearch(client, parsed, extractFuzzyTerms(originalQuery), true);
+  }
+
+  const exact = await client.searchNotes({
+    ...scopeParams(parsed),
+    search: effectiveQuery,
+    limit: parsed.limit,
+  });
+
+  if (mode === 'force') {
+    // Forced, but the query is structured — OR-expanding it would produce something
+    // syntactically different and probably invalid. Say so rather than pretend.
+    return {
+      ...exact,
+      searchMode: 'exact',
+      note:
+        'fuzzy="force" was ignored: this query uses Trilium syntax (attribute, property, ' +
+        'id:/title: prefix, or an existing OR) that must not be OR-expanded. Ran it exactly as written.',
+    };
+  }
+
+  if (!eligible || exact.results.length !== 0) {
+    return exact as unknown as Record<string, unknown>;
+  }
+
+  try {
+    return await runFuzzySearch(client, parsed, extractFuzzyTerms(originalQuery), false);
+  } catch {
+    // Best-effort retry. A failed rewrite must never turn a successful-but-empty
+    // search into a tool error.
+    return exact as unknown as Record<string, unknown>;
+  }
 }
 
 export async function handleSearchTool(
@@ -115,16 +281,15 @@ export async function handleSearchTool(
           };
         } catch (error) {
           if (error instanceof TriliumClientError && error.status === 404) {
-            // Note not found — fall back to regular search
-            const result = await client.searchNotes({
-              search: preprocessed.query,
-              fastSearch: parsed.fastSearch,
-              includeArchivedNotes: parsed.includeArchivedNotes,
-              ancestorNoteId: parsed.ancestorNoteId,
-              orderBy: parsed.orderBy,
-              orderDirection: parsed.orderDirection,
-              limit: parsed.limit,
-            });
+            // Note not found — fall back to regular search, but never fuzzily:
+            // an OR-expansion of a note ID is meaningless.
+            const result = await runSearchWithFallback(
+              client,
+              parsed,
+              preprocessed.query,
+              parsed.query,
+              false
+            );
             return {
               content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
             };
@@ -133,15 +298,13 @@ export async function handleSearchTool(
         }
       }
 
-      const result = await client.searchNotes({
-        search: preprocessed.query,
-        fastSearch: parsed.fastSearch,
-        includeArchivedNotes: parsed.includeArchivedNotes,
-        ancestorNoteId: parsed.ancestorNoteId,
-        orderBy: parsed.orderBy,
-        orderDirection: parsed.orderDirection,
-        limit: parsed.limit,
-      });
+      const result = await runSearchWithFallback(
+        client,
+        parsed,
+        preprocessed.query,
+        parsed.query,
+        true
+      );
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/tests/integration/etapi.test.ts
+++ b/tests/integration/etapi.test.ts
@@ -3,10 +3,17 @@ import { fileTypeFromBuffer } from 'file-type';
 import { TriliumClient } from '../../src/client/trilium.js';
 import { handleNoteTool } from '../../src/tools/notes.js';
 import { handleAttachmentTool } from '../../src/tools/attachments.js';
+import { handleSearchTool } from '../../src/tools/search.js';
 import { setupIntegrationTests, stopTriliumContainer } from './setup.js';
 
 describe('TriliumNext ETAPI Integration Tests', () => {
   let client: TriliumClient;
+
+  /** Run search_notes through the MCP handler and parse its JSON payload. */
+  async function runSearch(args: Record<string, unknown>) {
+    const result = await handleSearchTool(client, 'search_notes', args);
+    return JSON.parse((result?.content[0] as { text: string }).text);
+  }
 
   beforeAll(async () => {
     client = await setupIntegrationTests();
@@ -259,6 +266,79 @@ describe('TriliumNext ETAPI Integration Tests', () => {
 
       expect(result.results).toBeDefined();
       // Note: Trilium's ordering may not always be deterministic for similar titles
+    });
+
+    // These exercise the fuzzy fallback against a real Trilium, because the
+    // behavior it depends on (how `note.content *=*` OR queries and fastSearch
+    // actually interact) is not knowable from the ETAPI spec alone.
+    describe('fuzzy fallback', () => {
+      let fuzzyNoteId: string;
+
+      beforeAll(async () => {
+        const created = await client.createNote({
+          parentNoteId: 'root',
+          title: 'Volumetric Niagara Tutorial',
+          type: 'text',
+          content: '<p>Body text mentioning zephyrquux for content-only matching.</p>',
+        });
+        fuzzyNoteId = created.note.noteId;
+      });
+
+      it('AND semantics return nothing when one term is wrong', async () => {
+        const result = await client.searchNotes({
+          search: 'Volumetric Niagara nonexistentterm',
+        });
+        expect(result.results.some((n) => n.noteId === fuzzyNoteId)).toBe(false);
+      });
+
+      it('the OR rewrite finds the note the AND query missed', async () => {
+        const parsed = await runSearch({ query: 'Volumetric Niagara nonexistentterm' });
+
+        expect(parsed.searchMode).toBe('fuzzy');
+        expect(parsed.results.some((n: { noteId: string }) => n.noteId === fuzzyNoteId)).toBe(true);
+        // The bogus term should be visibly the odd one out.
+        expect(parsed.termsMatchedInTitleOrAttributes.nonexistentterm).toBe(0);
+      });
+
+      it('ranks the title match first', async () => {
+        const parsed = await runSearch({ query: 'Volumetric Niagara nonexistentterm' });
+        expect(parsed.results[0].noteId).toBe(fuzzyNoteId);
+      });
+
+      it('surfaces a content-only match rather than dropping it', async () => {
+        const parsed = await runSearch({ query: 'zephyrquux nonexistentterm' });
+
+        expect(parsed.searchMode).toBe('fuzzy');
+        expect(parsed.results.some((n: { noteId: string }) => n.noteId === fuzzyNoteId)).toBe(true);
+        // Nothing matched in the title or attributes — this note is here purely
+        // because Trilium matched its body, which is exactly what must not be filtered.
+        expect(parsed.termsMatchedInTitleOrAttributes.zephyrquux).toBe(0);
+      });
+
+      it('still works under fastSearch, via the title arms', async () => {
+        const parsed = await runSearch({
+          query: 'Volumetric Niagara nonexistentterm',
+          fastSearch: true,
+        });
+
+        expect(parsed.searchMode).toBe('fuzzy');
+        expect(parsed.results.some((n: { noteId: string }) => n.noteId === fuzzyNoteId)).toBe(true);
+      });
+
+      it('does not fuzz an attribute query', async () => {
+        const parsed = await runSearch({ query: '#nonexistentLabelXyz' });
+        expect(parsed.searchMode).toBeUndefined();
+        expect(parsed.results).toEqual([]);
+      });
+
+      it('returns the legacy shape when fuzzy is off', async () => {
+        const parsed = await runSearch({
+          query: 'Volumetric Niagara nonexistentterm',
+          fuzzy: 'off',
+        });
+        expect(parsed.searchMode).toBeUndefined();
+        expect(parsed.results).toEqual([]);
+      });
     });
 
     it('get_note_tree - should get children of root', async () => {

--- a/tests/unit/fuzzySearch.test.ts
+++ b/tests/unit/fuzzySearch.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_FUZZY_TERMS,
+  DEFAULT_FUZZY_RESULT_LIMIT,
+  extractFuzzyTerms,
+  isFuzzyEligible,
+  quoteTerm,
+  buildFuzzyQuery,
+  rankNotes,
+  resolveFuzzyLimit,
+} from '../../src/tools/fuzzySearch.js';
+import type { Attribute, Note } from '../../src/types/etapi.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+let noteSeq = 0;
+
+function makeNote(partial: Partial<Note> = {}): Note {
+  noteSeq += 1;
+  return {
+    noteId: `note${String(noteSeq).padStart(4, '0')}`,
+    title: 'Untitled',
+    type: 'text',
+    mime: 'text/html',
+    isProtected: false,
+    attributes: [],
+    parentNoteIds: ['root'],
+    childNoteIds: [],
+    parentBranchIds: ['branch1'],
+    childBranchIds: [],
+    dateCreated: '2026-01-01 00:00:00.000+0000',
+    dateModified: '2026-01-01 00:00:00.000+0000',
+    utcDateCreated: '2026-01-01T00:00:00.000Z',
+    utcDateModified: '2026-01-01T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+function attribute(type: 'label' | 'relation', name: string, value: string): Attribute {
+  return {
+    attributeId: `${type}_${name}`,
+    noteId: 'n',
+    type,
+    name,
+    value,
+    position: 10,
+    isInheritable: false,
+    utcDateModified: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const label = (name: string, value: string) => attribute('label', name, value);
+const relation = (name: string, value: string) => attribute('relation', name, value);
+
+const titlesOf = (notes: Note[]) => notes.map((n) => n.title);
+
+// ============================================================================
+// extractFuzzyTerms
+// ============================================================================
+
+describe('extractFuzzyTerms', () => {
+  it('splits a mixed CJK/ASCII query into terms', () => {
+    expect(extractFuzzyTerms('体积云 Niagara 教程')).toEqual(['体积云', 'Niagara', '教程']);
+  });
+
+  it('keeps single-character CJK terms', () => {
+    expect(extractFuzzyTerms('的 中 文')).toEqual(['的', '中', '文']);
+  });
+
+  it('drops single-character ASCII terms', () => {
+    expect(extractFuzzyTerms('a b cat')).toEqual(['cat']);
+  });
+
+  it('keeps a quoted phrase as one term', () => {
+    expect(extractFuzzyTerms('"meeting notes" project')).toEqual(['meeting notes', 'project']);
+  });
+
+  it('unescapes quotes inside a quoted phrase', () => {
+    expect(extractFuzzyTerms('"say \\"hi\\"" project')).toEqual(['say "hi"', 'project']);
+  });
+
+  it('deduplicates case-insensitively, preserving first-seen casing', () => {
+    expect(extractFuzzyTerms('Meeting meeting MEETING notes')).toEqual(['Meeting', 'notes']);
+  });
+
+  it('strips CJK trailing punctuation', () => {
+    expect(extractFuzzyTerms('教程。 体积云、')).toEqual(['教程', '体积云']);
+  });
+
+  it('strips ASCII surrounding punctuation', () => {
+    expect(extractFuzzyTerms('urgent! important,')).toEqual(['urgent', 'important']);
+  });
+
+  it('caps the number of terms', () => {
+    const many = Array.from({ length: 20 }, (_, i) => `term${i}`).join(' ');
+    expect(extractFuzzyTerms(many)).toHaveLength(MAX_FUZZY_TERMS);
+  });
+
+  it('returns nothing for empty or whitespace-only input', () => {
+    expect(extractFuzzyTerms('')).toEqual([]);
+    expect(extractFuzzyTerms('   ')).toEqual([]);
+  });
+});
+
+// ============================================================================
+// isFuzzyEligible
+// ============================================================================
+
+describe('isFuzzyEligible', () => {
+  describe('auto mode', () => {
+    it.each([['meeting notes'], ['体积云 Niagara 教程'], ['"exact phrase" other']])(
+      'accepts plain fulltext: %s',
+      (query) => {
+        expect(isFuzzyEligible(query, 'auto')).toBe(true);
+      }
+    );
+
+    it('rejects a single-term query (the OR retry would be a duplicate)', () => {
+      expect(isFuzzyEligible('meeting', 'auto')).toBe(false);
+    });
+
+    it('rejects a query whose tokens all fall below the term threshold', () => {
+      expect(isFuzzyEligible('a b', 'auto')).toBe(false);
+    });
+
+    it.each([
+      ['#project'],
+      ['#status = active'],
+      ['note.title *=* x'],
+      ['~rel foo'],
+      ['(a b) c'],
+      ['not(#x) y'],
+    ])('rejects structured query syntax: %s', (query) => {
+      expect(isFuzzyEligible(query, 'auto')).toBe(false);
+    });
+
+    it('rejects a trailing paren that isBareFulltextSegment would miss', () => {
+      expect(isFuzzyEligible('foo) bar', 'auto')).toBe(false);
+    });
+
+    it.each([['a or b'], ['a OR b']])('rejects an already-OR query: %s', (query) => {
+      expect(isFuzzyEligible(query, 'auto')).toBe(false);
+    });
+
+    it.each([['title:meeting notes'], ['id:abc123'], ['abc123def']])(
+      'rejects explicitly scoped lookups: %s',
+      (query) => {
+        expect(isFuzzyEligible(query, 'auto')).toBe(false);
+      }
+    );
+
+    it.each([[''], ['   ']])('rejects empty input: %s', (query) => {
+      expect(isFuzzyEligible(query, 'auto')).toBe(false);
+    });
+  });
+
+  describe('force mode', () => {
+    it('accepts a single-term query', () => {
+      expect(isFuzzyEligible('meeting', 'force')).toBe(true);
+    });
+
+    it('still rejects structured query syntax', () => {
+      expect(isFuzzyEligible('#project', 'force')).toBe(false);
+      expect(isFuzzyEligible('title:meeting notes', 'force')).toBe(false);
+    });
+
+    it('still rejects empty input', () => {
+      expect(isFuzzyEligible('   ', 'force')).toBe(false);
+    });
+  });
+
+  describe('off mode', () => {
+    it('is never eligible', () => {
+      expect(isFuzzyEligible('meeting notes', 'off')).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// quoteTerm / buildFuzzyQuery
+// ============================================================================
+
+describe('quoteTerm', () => {
+  it('quotes a plain term', () => {
+    expect(quoteTerm('meeting')).toBe('"meeting"');
+  });
+
+  it('quotes a multi-word phrase', () => {
+    expect(quoteTerm('meeting notes')).toBe('"meeting notes"');
+  });
+
+  it('escapes embedded double quotes', () => {
+    expect(quoteTerm('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it('escapes backslashes before quotes, so they do not double-escape', () => {
+    expect(quoteTerm('back\\slash')).toBe('"back\\\\slash"');
+    expect(quoteTerm('mix\\"both')).toBe('"mix\\\\\\"both"');
+  });
+
+  it('quotes CJK terms', () => {
+    expect(quoteTerm('体积云')).toBe('"体积云"');
+  });
+});
+
+describe('buildFuzzyQuery', () => {
+  it('emits content and title arms for each term, OR-joined', () => {
+    expect(buildFuzzyQuery(['cat', 'dog'])).toBe(
+      'note.content *=* "cat" OR note.title *=* "cat" OR ' +
+        'note.content *=* "dog" OR note.title *=* "dog"'
+    );
+  });
+
+  it('escapes terms it embeds', () => {
+    expect(buildFuzzyQuery(['say "hi"'])).toBe(
+      'note.content *=* "say \\"hi\\"" OR note.title *=* "say \\"hi\\""'
+    );
+  });
+});
+
+// ============================================================================
+// rankNotes
+// ============================================================================
+
+describe('rankNotes', () => {
+  // This is the headline regression guard against PR #55, whose ranker only counted
+  // title hits and then filtered on that count — silently discarding every note that
+  // matched on content. Trilium already decided these notes matched; ranking may
+  // reorder them but must never drop them.
+  it('never drops notes that have no title or attribute evidence', () => {
+    const notes = [
+      makeNote({ title: 'Completely unrelated' }),
+      makeNote({ title: 'Also unrelated' }),
+      makeNote({ title: 'Still unrelated' }),
+    ];
+    const ranked = rankNotes(notes, ['体积云', 'Niagara']);
+    expect(ranked).toHaveLength(3);
+  });
+
+  it('returns the original note objects by reference, unmodified', () => {
+    const target = makeNote({ title: 'Niagara particles' });
+    const notes = [makeNote({ title: 'Unrelated' }), target];
+    const ranked = rankNotes(notes, ['niagara']);
+
+    expect(ranked[0].note).toBe(target);
+    expect(Object.keys(ranked[0].note).sort()).toEqual(Object.keys(makeNote()).sort());
+    expect(ranked[0].note).not.toHaveProperty('_score');
+    expect(ranked[0].note).not.toHaveProperty('_matchedTerms');
+  });
+
+  it('ranks all-terms-in-title above one-term-in-title above attribute-only above nothing', () => {
+    const nothing = makeNote({ title: 'Unrelated' });
+    const attrOnly = makeNote({ title: 'Unrelated too', attributes: [label('topic', 'niagara')] });
+    const oneTerm = makeNote({ title: 'Niagara basics' });
+    const allTerms = makeNote({ title: 'Niagara 教程 walkthrough' });
+
+    const ranked = rankNotes([nothing, attrOnly, oneTerm, allTerms], ['niagara', '教程']);
+    expect(titlesOf(ranked.map((r) => r.note))).toEqual([
+      'Niagara 教程 walkthrough',
+      'Niagara basics',
+      'Unrelated too',
+      'Unrelated',
+    ]);
+  });
+
+  it('scores relation attributes, not just labels', () => {
+    const withRelation = makeNote({ title: 'Zed', attributes: [relation('template', 'niagara')] });
+    const without = makeNote({ title: 'Alpha' });
+    const ranked = rankNotes([without, withRelation], ['niagara']);
+    expect(ranked[0].note).toBe(withRelation);
+  });
+
+  it('scores an attribute name, not just its value', () => {
+    const byName = makeNote({ title: 'Zed', attributes: [label('niagara', 'whatever')] });
+    const without = makeNote({ title: 'Alpha' });
+    const ranked = rankNotes([without, byName], ['niagara']);
+    expect(ranked[0].note).toBe(byName);
+  });
+
+  it('scores labels of any name, not only ones named "tag"', () => {
+    const arbitrary = makeNote({ title: 'Zed', attributes: [label('anything', 'niagara')] });
+    const without = makeNote({ title: 'Alpha' });
+    const ranked = rankNotes([without, arbitrary], ['niagara']);
+    expect(ranked[0].note).toBe(arbitrary);
+  });
+
+  it('matches titles case-insensitively', () => {
+    const upper = makeNote({ title: 'NIAGARA GUIDE' });
+    const ranked = rankNotes([makeNote({ title: 'Unrelated' }), upper], ['niagara']);
+    expect(ranked[0].note).toBe(upper);
+  });
+
+  it('treats full-width and half-width characters as equivalent (NFKC)', () => {
+    const fullWidth = makeNote({ title: 'Ｎｉａｇａｒａ 教程' });
+    const ranked = rankNotes([makeNote({ title: 'Unrelated' }), fullWidth], ['niagara']);
+    expect(ranked[0].note).toBe(fullWidth);
+  });
+
+  it('prefers the shorter title when scores tie', () => {
+    // Both match the single term, both start with it, neither equals it exactly —
+    // so every scoring signal is identical and only the length tie-break separates them.
+    const short = makeNote({ title: 'Niagara guide' });
+    const long = makeNote({ title: 'Niagara guidebook extended' });
+    const ranked = rankNotes([long, short], ['niagara']);
+    expect(ranked[0].note).toBe(short);
+  });
+
+  it('produces the same ordering regardless of input order', () => {
+    const notes = [
+      makeNote({ title: 'Niagara 教程 deep dive' }),
+      makeNote({ title: 'Unrelated' }),
+      makeNote({ title: 'Niagara basics' }),
+      makeNote({ title: 'Another unrelated' }),
+    ];
+    const forward = rankNotes(notes, ['niagara', '教程']).map((r) => r.note.noteId);
+    const reversed = rankNotes([...notes].reverse(), ['niagara', '教程']).map((r) => r.note.noteId);
+    expect(reversed).toEqual(forward);
+  });
+
+  it('reports which terms each note matched', () => {
+    const note = makeNote({ title: 'Niagara guide', attributes: [label('topic', '教程')] });
+    const [ranked] = rankNotes([note], ['niagara', '教程', 'unrelated']);
+    expect(ranked.matchedTerms.sort()).toEqual(['niagara', '教程']);
+  });
+
+  it('tolerates missing attributes and title without throwing', () => {
+    const malformed = { ...makeNote(), attributes: undefined, title: undefined } as unknown as Note;
+    expect(() => rankNotes([malformed], ['niagara'])).not.toThrow();
+    expect(rankNotes([malformed], ['niagara'])).toHaveLength(1);
+  });
+
+  it('returns an empty array for no notes', () => {
+    expect(rankNotes([], ['niagara'])).toEqual([]);
+  });
+});
+
+// ============================================================================
+// resolveFuzzyLimit
+// ============================================================================
+
+describe('resolveFuzzyLimit', () => {
+  it('over-fetches by default so there is something to rank', () => {
+    expect(resolveFuzzyLimit(undefined)).toEqual({
+      fetchLimit: 200,
+      sliceTo: DEFAULT_FUZZY_RESULT_LIMIT,
+    });
+  });
+
+  it('scales the recall window with a small caller limit', () => {
+    expect(resolveFuzzyLimit(10)).toEqual({ fetchLimit: 40, sliceTo: 10 });
+  });
+
+  it('never fetches fewer candidates than the caller asked to receive', () => {
+    // PR #55 hardcoded 200, silently capping a caller who asked for 500.
+    const { fetchLimit, sliceTo } = resolveFuzzyLimit(500);
+    expect(sliceTo).toBe(500);
+    expect(fetchLimit).toBeGreaterThanOrEqual(500);
+  });
+
+  it('never exceeds the schema ceiling', () => {
+    expect(resolveFuzzyLimit(10000).fetchLimit).toBeLessThanOrEqual(10000);
+  });
+
+  it('always fetches at least as many as it returns', () => {
+    for (const limit of [1, 5, 25, 50, 199, 200, 201, 1000, 9999, 10000]) {
+      const { fetchLimit, sliceTo } = resolveFuzzyLimit(limit);
+      expect(fetchLimit).toBeGreaterThanOrEqual(sliceTo);
+    }
+  });
+});

--- a/tests/unit/queryPreprocessor.test.ts
+++ b/tests/unit/queryPreprocessor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { preprocessSearchQuery } from '../../src/tools/queryPreprocessor.js';
+import {
+  preprocessSearchQuery,
+  tokenize,
+  isBareFulltextSegment,
+  isOrOperator,
+} from '../../src/tools/queryPreprocessor.js';
 
 describe('preprocessSearchQuery', () => {
   describe('passthrough (no transformation needed)', () => {
@@ -213,5 +218,66 @@ describe('preprocessSearchQuery', () => {
       // "title:" alone — no value, falls through
       expect(preprocessSearchQuery('title:')).toEqual({ type: 'search', query: 'title:' });
     });
+  });
+});
+
+// These three helpers are public API because fuzzySearch.ts reuses them — having a
+// single definition of "how do we split a query" and "is this plain fulltext" is the
+// point. Tests below pin the behavior that module now depends on.
+
+describe('tokenize', () => {
+  it('should split on whitespace', () => {
+    expect(tokenize('meeting notes project')).toEqual(['meeting', 'notes', 'project']);
+  });
+
+  it('should keep a quoted phrase as one token', () => {
+    expect(tokenize('"meeting notes" project')).toEqual(['"meeting notes"', 'project']);
+  });
+
+  it('should keep escaped quotes inside a quoted phrase', () => {
+    expect(tokenize('"say \\"hi\\"" x')).toEqual(['"say \\"hi\\""', 'x']);
+  });
+
+  it('should collapse repeated whitespace', () => {
+    expect(tokenize('  a   b  ')).toEqual(['a', 'b']);
+  });
+
+  it('should return nothing for an empty query', () => {
+    expect(tokenize('')).toEqual([]);
+    expect(tokenize('   ')).toEqual([]);
+  });
+});
+
+describe('isOrOperator', () => {
+  it('should match "or" in any casing', () => {
+    expect(isOrOperator('or')).toBe(true);
+    expect(isOrOperator('OR')).toBe(true);
+    expect(isOrOperator('Or')).toBe(true);
+  });
+
+  it('should not match words merely containing "or"', () => {
+    expect(isOrOperator('order')).toBe(false);
+    expect(isOrOperator('"or"')).toBe(false);
+  });
+});
+
+describe('isBareFulltextSegment', () => {
+  it('should accept plain words', () => {
+    expect(isBareFulltextSegment(['meeting', 'notes'])).toBe(true);
+  });
+
+  it.each([[['#project']], [['~relation']], [['note.title']], [['not(#x)']], [['(a']], [['a=b']]])(
+    'should reject structured token %s',
+    (tokens) => {
+      expect(isBareFulltextSegment(tokens)).toBe(false);
+    }
+  );
+
+  it('is a rewriting heuristic, not a validator: a trailing paren slips through', () => {
+    // Documented asymmetry — it inspects token PREFIXES, so ")foo" is caught but
+    // "foo)" is not. Callers using it as a safety gate must add a stricter check
+    // of their own (fuzzySearch.ts does exactly that).
+    expect(isBareFulltextSegment([')foo'])).toBe(false);
+    expect(isBareFulltextSegment(['foo)'])).toBe(true);
   });
 });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1248,4 +1248,36 @@ describe('Total tool surface', () => {
       expect(t.inputSchema.type).toBe('object');
     }
   });
+
+  // An MCP inputSchema describes what the CALLER sends, i.e. the input side of the
+  // schema. Zod's toJSONSchema() defaults to OUTPUT semantics, where a `.default()`
+  // field is always present and therefore lands in `required` — which would advertise
+  // optional parameters to clients as mandatory. defineTool must pass io: 'input'.
+  it('no parameter with a default is advertised as required', () => {
+    const allTools = [
+      ...registerSearchTools(),
+      ...registerNoteTools(),
+      ...registerRevisionTools(),
+      ...registerAttributeTools(),
+      ...registerAttachmentTools(),
+      ...registerCalendarTools(),
+      ...registerOrganizationTools(),
+      ...registerSystemTools(),
+    ];
+    for (const t of allTools) {
+      const required = t.inputSchema.required ?? [];
+      const properties = (t.inputSchema.properties ?? {}) as Record<
+        string,
+        { default?: unknown }
+      >;
+      for (const [name, prop] of Object.entries(properties)) {
+        if (prop?.default !== undefined) {
+          expect(
+            required,
+            `${t.name}.${name} has a default but is listed as required`
+          ).not.toContain(name);
+        }
+      }
+    }
+  });
 });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../src/tools/attachments.js';
 import { registerRevisionTools, handleRevisionTool } from '../../src/tools/revisions.js';
 import type { TriliumClient } from '../../src/client/trilium.js';
+import { TriliumClientError } from '../../src/client/trilium.js';
 import { NOTE_TYPES } from '../../src/tools/validators.js';
 
 // ============================================================================
@@ -536,6 +537,257 @@ describe('Search tools', () => {
     const result = await handleSearchTool(client, 'get_note_tree', { noteId: 'root' });
     const parsed = JSON.parse((result?.content[0] as { text: string }).text);
     expect(parsed.childNoteIds).toEqual(['c1']);
+  });
+});
+
+// ============================================================================
+// Search — graceful fuzzy fallback
+// ============================================================================
+
+describe('search_notes fuzzy fallback', () => {
+  function searchNote(title: string, extra: Record<string, unknown> = {}) {
+    return {
+      noteId: `id_${title.replace(/\W+/g, '_')}`,
+      title,
+      type: 'text',
+      mime: 'text/html',
+      isProtected: false,
+      attributes: [],
+      parentNoteIds: ['root'],
+      childNoteIds: [],
+      parentBranchIds: ['b1'],
+      childBranchIds: [],
+      dateCreated: '2026-01-01 00:00:00.000+0000',
+      dateModified: '2026-01-01 00:00:00.000+0000',
+      utcDateCreated: '2026-01-01T00:00:00.000Z',
+      utcDateModified: '2026-01-01T00:00:00.000Z',
+      ...extra,
+    };
+  }
+
+  const mockSearch = (client: TriliumClient) => client.searchNotes as ReturnType<typeof vi.fn>;
+  const callArgs = (client: TriliumClient, n: number) => mockSearch(client).mock.calls[n][0];
+  const parse = (result: { content: Array<{ type: 'text'; text: string }> } | null) =>
+    JSON.parse((result?.content[0] as { text: string }).text);
+  const rawText = (result: { content: Array<{ type: 'text'; text: string }> } | null) =>
+    (result?.content[0] as { text: string }).text;
+
+  it('does not retry when the exact search found something', async () => {
+    const client = createMockClient();
+    const response = { results: [searchNote('Niagara guide')] };
+    mockSearch(client).mockResolvedValue(response);
+
+    const result = await handleSearchTool(client, 'search_notes', { query: 'niagara 教程' });
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+    // Byte-identical to the pre-feature response shape.
+    expect(rawText(result)).toBe(JSON.stringify(response, null, 2));
+  });
+
+  it('retries a zero-result multi-term query as a ranked OR search', async () => {
+    const client = createMockClient();
+    mockSearch(client)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [searchNote('Niagara 教程')] });
+
+    const parsed = parse(await handleSearchTool(client, 'search_notes', { query: 'niagara 教程' }));
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(2);
+    expect(callArgs(client, 1).search).toContain(' OR ');
+    expect(parsed.searchMode).toBe('fuzzy');
+    expect(parsed.fuzzyTerms).toEqual(['niagara', '教程']);
+    expect(parsed.results).toHaveLength(1);
+  });
+
+  it('never retries when fuzzy is off', async () => {
+    const client = createMockClient();
+    const response = { results: [] };
+    mockSearch(client).mockResolvedValue(response);
+
+    const result = await handleSearchTool(client, 'search_notes', {
+      query: 'niagara 教程',
+      fuzzy: 'off',
+    });
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+    expect(rawText(result)).toBe(JSON.stringify(response, null, 2));
+    expect(parse(result)).not.toHaveProperty('searchMode');
+  });
+
+  it('never retries an attribute query', async () => {
+    const client = createMockClient();
+    mockSearch(client).mockResolvedValue({ results: [] });
+    await handleSearchTool(client, 'search_notes', { query: '#project' });
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries a single-term query', async () => {
+    const client = createMockClient();
+    mockSearch(client).mockResolvedValue({ results: [] });
+    await handleSearchTool(client, 'search_notes', { query: 'meeting' });
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it('goes straight to the OR search when forced', async () => {
+    const client = createMockClient();
+    mockSearch(client).mockResolvedValue({ results: [searchNote('Meeting notes')] });
+
+    const parsed = parse(
+      await handleSearchTool(client, 'search_notes', { query: 'meeting', fuzzy: 'force' })
+    );
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+    expect(callArgs(client, 0).search).toContain('note.content *=*');
+    expect(parsed.searchMode).toBe('fuzzy');
+  });
+
+  it('does not claim an exact search failed when it was never run', async () => {
+    const client = createMockClient();
+    mockSearch(client).mockResolvedValue({ results: [searchNote('Meeting notes')] });
+
+    const forced = parse(
+      await handleSearchTool(client, 'search_notes', { query: 'meeting', fuzzy: 'force' })
+    );
+    expect(forced.note).not.toContain('No notes matched');
+
+    const client2 = createMockClient();
+    mockSearch(client2)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [searchNote('Niagara 教程')] });
+    const auto = parse(await handleSearchTool(client2, 'search_notes', { query: 'niagara 教程' }));
+    expect(auto.note).toContain('No notes matched');
+  });
+
+  it('reports exact mode when force is used on an ineligible query', async () => {
+    const client = createMockClient();
+    mockSearch(client).mockResolvedValue({ results: [] });
+
+    const parsed = parse(
+      await handleSearchTool(client, 'search_notes', { query: '#project', fuzzy: 'force' })
+    );
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+    expect(parsed.searchMode).toBe('exact');
+    expect(parsed.note).toBeTruthy();
+  });
+
+  it('falls back to the exact response when the retry itself fails', async () => {
+    const client = createMockClient();
+    const exact = { results: [] };
+    mockSearch(client)
+      .mockResolvedValueOnce(exact)
+      .mockRejectedValueOnce(new Error('trilium exploded'));
+
+    const result = await handleSearchTool(client, 'search_notes', { query: 'niagara 教程' });
+
+    expect(rawText(result)).toBe(JSON.stringify(exact, null, 2));
+  });
+
+  it('orders fuzzy results by relevance without touching the note objects', async () => {
+    const client = createMockClient();
+    mockSearch(client)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({
+        results: [searchNote('Unrelated note'), searchNote('Niagara 教程 deep dive')],
+      });
+
+    const parsed = parse(await handleSearchTool(client, 'search_notes', { query: 'niagara 教程' }));
+
+    expect(parsed.results[0].title).toBe('Niagara 教程 deep dive');
+    expect(parsed.results[0]).not.toHaveProperty('_score');
+    expect(parsed.results[0]).not.toHaveProperty('_matchedTerms');
+  });
+
+  it('honors the caller limit while over-fetching candidates to rank', async () => {
+    const client = createMockClient();
+    mockSearch(client)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({
+        results: ['a', 'b', 'c', 'd', 'e'].map((t) => searchNote(`Niagara ${t}`)),
+      });
+
+    const parsed = parse(
+      await handleSearchTool(client, 'search_notes', { query: 'niagara 教程', limit: 2 })
+    );
+
+    expect(parsed.results).toHaveLength(2);
+    expect(parsed.totalCandidates).toBe(5);
+    expect(callArgs(client, 1).limit).toBeGreaterThan(2);
+  });
+
+  it('carries scope filters through to the retry', async () => {
+    const client = createMockClient();
+    mockSearch(client).mockResolvedValue({ results: [] });
+
+    await handleSearchTool(client, 'search_notes', {
+      query: 'niagara 教程',
+      ancestorNoteId: 'abc123',
+      includeArchivedNotes: true,
+      fastSearch: true,
+    });
+
+    expect(callArgs(client, 1)).toMatchObject({
+      ancestorNoteId: 'abc123',
+      includeArchivedNotes: true,
+      fastSearch: true,
+    });
+  });
+
+  it('preserves an explicit orderBy instead of re-ranking', async () => {
+    const client = createMockClient();
+    const ordered = [searchNote('Unrelated note'), searchNote('Niagara 教程 deep dive')];
+    mockSearch(client)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: ordered });
+
+    const parsed = parse(
+      await handleSearchTool(client, 'search_notes', {
+        query: 'niagara 教程',
+        orderBy: 'dateModified',
+      })
+    );
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(2);
+    expect(parsed.results.map((n: { title: string }) => n.title)).toEqual([
+      'Unrelated note',
+      'Niagara 教程 deep dive',
+    ]);
+  });
+
+  it('never fuzzes the noteId-lookup 404 fallback path', async () => {
+    const client = createMockClient();
+    (client.getNote as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new TriliumClientError(404, 'NOTE_NOT_FOUND', 'not found')
+    );
+    mockSearch(client).mockResolvedValue({ results: [] });
+
+    await handleSearchTool(client, 'search_notes', { query: 'id:abc123' });
+
+    expect(client.searchNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports which terms had title or attribute evidence', async () => {
+    const client = createMockClient();
+    mockSearch(client)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [searchNote('Niagara guide')] });
+
+    const parsed = parse(await handleSearchTool(client, 'search_notes', { query: 'niagara 教程' }));
+
+    expect(parsed.termsMatchedInTitleOrAttributes).toEqual({ niagara: 1, 教程: 0 });
+  });
+
+  it('preserves debugInfo from the retry', async () => {
+    const client = createMockClient();
+    mockSearch(client)
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [], debugInfo: { parsed: 'yes' } });
+
+    const parsed = parse(await handleSearchTool(client, 'search_notes', { query: 'niagara 教程' }));
+
+    expect(parsed.debugInfo).toEqual({ parsed: 'yes' });
+    expect(parsed.results).toEqual([]);
+    expect(parsed.searchMode).toBe('fuzzy');
   });
 });
 


### PR DESCRIPTION
Builds on the idea in #55 by @youli42, credited as co-author on the feature commit.

## The problem

Trilium's fulltext search is implicit-AND, so `体积云 Niagara 教程` returns **zero results** if any single term is wrong — and zero results tell the caller nothing about *which* term was the bad one. For an LLM working from partial recall that is the worst possible outcome: nothing to recover from, so it gives up.

## What this does

`search_notes` gains one parameter, `fuzzy`:

| Value | Behavior |
|-------|----------|
| `auto` (default) | Run the query as written. If it returns **zero** results and the query is eligible, retry as a relevance-ranked OR over the individual terms. |
| `off` | Never retry. Byte-identical to today's behavior. |
| `force` | Skip the exact attempt, go straight to the ranked OR. |

Only plain-fulltext queries with 2+ terms are eligible. Attribute filters (`#project`), property expressions (`note.title *=* x`), `id:`/`title:` prefixes, and queries already containing `or` are never rewritten — expanding those would change what was asked rather than widen it. Terms are capped at 8, since each becomes an unindexed substring scan.

When the fallback fires, note objects are returned **unmodified**; relevance is conveyed by sort order plus top-level siblings:

```jsonc
{
  "results": [ /* unmodified notes, most relevant first */ ],
  "searchMode": "fuzzy",
  "fuzzyTerms": ["体积云", "Niagara", "教程"],
  "totalCandidates": 12,
  "termsMatchedInTitleOrAttributes": { "体积云": 12, "Niagara": 0, "教程": 9 },
  "note": "..."
}
```

`termsMatchedInTitleOrAttributes` is the "which term was wrong?" signal — a `0` is the term to drop and re-query without.

## Why one tool instead of two

#55 proposed this as a separate `fuzzy_search_notes` tool. Folding it into `search_notes` instead keeps `EXPECTED_TOOL_COUNT` at 19 — the count the v1→v2 trim (#6) exists to defend — and spares the model a choice between two near-synonymous search tools, which models tend to get wrong. It also means the failure mode self-heals rather than depending on the model knowing to retry.

## Differences from #55

The reimplementation fixes several issues in that patch:

- **The ranker no longer discards content-only matches.** #55 incremented `matchedTerms` on title hits only, then filtered `matchedTerms >= threshold` — so an expensive 200-note content search was silently reduced to a title search. Here `rankNotes` sorts but never filters: every note Trilium returned already matched something.
- Quoted terms escape embedded `"` and `\` (unescaped quotes produced malformed queries).
- Any label **or relation** contributes, matched on name **or** value — not only labels literally named `tag`.
- Single-character CJK terms survive tokenization (`length >= 2` dropped them).
- The recall limit derives from the caller's `limit` instead of a hardcoded 200, which silently capped anyone asking for more.
- Tokenization is shared with `queryPreprocessor` rather than duplicated.

## Known limitation

Ranking is title- and attribute-only, because ETAPI's search response carries no note content and scoring it would cost one HTTP request per candidate. A note matching only in its body is still returned but ranks low — the response says so explicitly, and `totalCandidates` makes a truncated view visible as truncated.

Also note `auto` is a silent behavior change for anyone relying on "zero results means zero": they now get a second round-trip and a different response shape. Fine for LLM callers, breaking for programmatic ones — worth a minor version bump.

## Second commit: a pre-existing schema bug

While adding a defaulted parameter I found `defineTool` was calling `toJSONSchema()` without `io: 'input'`. Zod v4 defaults to **output** semantics, under which `.default()` fields land in `required`. `include_content` on `get_note`, `get_revisions`, and `get_attachment` was therefore being advertised to every MCP client as mandatory, with its default omitted. Fixed in its own commit so it can be reverted independently, and guarded by a test across all 19 tools.

## Verification

- lint / typecheck / build clean
- 519 unit tests pass
- 149 integration tests pass against a real Trilium container; `list_tools` still reports 19

Two checks worth calling out:

- The headline regression guard was **mutation-tested**: reintroducing #55's filter makes three tests fail.
- Seven new integration tests run against a real Trilium, covering the two behaviors not knowable from the ETAPI spec — that `fastSearch` degrades cleanly to the title arms rather than erroring, and that a content-only match survives end-to-end. One also pins the premise: the AND query really does return nothing when a term is wrong.