### PR TITLE
feat: accept file paths, URLs, and data URLs for all content inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Options:
 - `--max-post-bytes <size>` — max size of a single MCP JSON-RPC POST body on the SSE transport. Accepts raw bytes or suffixed values like `500mb` / `1gb` (default: `500mb`). See [Request body size limits](#request-body-size-limits).
 - `-h, --help` — Show help message
 
+Content input options (see [Providing file content](#providing-file-content-paths-urls-base64)):
+- `--allow-local-file-read` / `--no-local-file-read` — permit tool inputs that name local file paths (default: on for stdio, off for `--transport http`)
+- `--local-file-roots <dirs>` — comma-separated directories content may be read from (default: unrestricted when reads are allowed)
+- `--content-url-allowlist <hosts>` — comma-separated hostnames permitted for http(s) content fetches (default: any public host)
+- `--max-content-fetch-bytes <size>` — max content file read / URL download size (default: `50mb`)
+
 Multi-tenant HTTP options (see [Multi-tenant HTTP deployment](#multi-tenant-http-deployment) below):
 - `--multi-tenant` — each SSE client supplies its own Trilium URL + token
 - `--gateway-auth <mode>` — `none` or `bearer` (default: `bearer` when multi-tenant)
@@ -100,6 +106,12 @@ export TRILIUM_PUBLIC_URL=https://trilium.example.com  # optional; web URL for n
 export TRILIUM_TRANSPORT=stdio
 export TRILIUM_HTTP_PORT=3000
 export TRILIUM_MAX_POST_BYTES=500mb  # SSE POST body cap; see "Request body size limits"
+
+# Content input (file paths / URLs in attachment and image tool inputs):
+export TRILIUM_ALLOW_LOCAL_FILE_READ=true   # default: true for stdio, false for http
+export TRILIUM_LOCAL_FILE_ROOTS=/srv/uploads
+export TRILIUM_CONTENT_URL_ALLOWLIST=example.com
+export TRILIUM_MAX_CONTENT_FETCH_BYTES=50mb
 
 # Multi-tenant (see section below):
 export TRILIUM_MULTI_TENANT=true
@@ -550,6 +562,42 @@ The tool surface was consolidated in a breaking release. The mapping from the ol
 ## Embedding Images and Files
 
 When creating or updating notes, you can embed images and files directly in a single tool call using the `images` and `files` parameters.
+
+### Providing file content (paths, URLs, base64)
+
+Every content-carrying input — `create_attachment.content`, `write_attachment` replace `content`, the `data` field of `images[]`/`files[]` entries, and binary note `content` — accepts **any** of these forms, auto-detected:
+
+| Form | Example | Notes |
+|---|---|---|
+| Local file path | `/tmp/screenshots/from-disk.png`, `~/docs/report.pdf` | The big win: the model never re-encodes bytes it already has on disk. Stdio transport only by default. |
+| `file://` path | `file:///tmp/shot.png` | Forces path interpretation (no fallthrough). |
+| http(s) URL | `https://example.com/logo.png` | The server fetches it (SSRF-guarded, 50 MB cap). |
+| Data URL | `data:image/png;base64,iVBORw0KGgo...` | Its MIME type wins over everything. |
+| Inline base64 / raw text | `iVBORw0KGgo...` / `plain notes here` | Today's behavior, unchanged. |
+
+`mime`, `filename`, and `create_attachment.title` are now **optional**: the MIME type is resolved from the data-URL header, then an explicit `mime`, then magic-byte sniffing, then the file extension; a path/URL basename becomes the default filename/title. The simplest possible calls:
+
+```json
+{ "tool": "create_attachment", "arguments": { "ownerId": "abc123", "role": "image", "content": "/tmp/screenshots/from-disk.png" } }
+```
+
+```json
+{ "tool": "create_note", "arguments": { "parentNoteId": "root", "title": "Image From Disk", "type": "text", "content": "<p>Look:</p><img src=\"image:0\">", "images": [{ "data": "/tmp/screenshots/from-disk.png" }] } }
+```
+
+```json
+{ "files": [{ "data": "/tmp/exports/stats.csv" }] }
+```
+
+(These shapes are exercised verbatim by `tests/integration/etapi.test.ts` › "Content input normalization".)
+
+Detection is verification-gated, so existing inline content can never be misread: a string only counts as a path when it is ≤ 1024 characters **and** names an existing regular file (JPEG base64 starts with `/9j/` but never survives both checks), and prose is never silently decoded as base64 — an undetectable inline input with no `mime` returns an actionable error instead of a guess.
+
+Security knobs (see [CLI Arguments](#cli-arguments)):
+
+- Local path reads are **enabled for stdio** (the server runs on your own machine) and **disabled for `--transport http`**, where a path would read the *server's* filesystem on behalf of a remote client. Override with `--allow-local-file-read` / `--no-local-file-read`, and optionally sandbox with `--local-file-roots /srv/uploads`.
+- URL fetches pass the same SSRF guard as multi-tenant Trilium URLs (private/loopback/metadata IPs blocked unless `--allow-private-urls`), re-checked on every redirect hop, with a `--max-content-fetch-bytes` cap (default 50 MB).
+- Trilium applies its own image compression settings server-side; the MCP always uploads the original bytes untouched.
 
 ### Image Embedding
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,6 +91,29 @@ export interface Config {
    */
   maxPostBytes: number;
   /**
+   * Permit tool inputs that name local file paths (attachment/image content).
+   * Defaults to true for stdio (the operator's own machine) and false for the
+   * http transport, where an LLM-supplied path would read the SERVER's
+   * filesystem on behalf of an arbitrary client.
+   */
+  allowLocalFileRead: boolean;
+  /**
+   * When non-empty, restrict content file reads to these directories
+   * (realpath-checked, so symlinks cannot escape). Empty = unrestricted.
+   */
+  localFileRoots: string[];
+  /**
+   * Hostname allowlist for http(s) CONTENT fetches (attachment/image inputs).
+   * Separate from `urlAllowlist`, which governs client-supplied Trilium hosts.
+   * Empty means any public host (private IPs still blocked unless
+   * `allowPrivateUrls`).
+   */
+  contentUrlAllowlist: string[];
+  /**
+   * Maximum bytes for a single content file read or URL download.
+   */
+  maxContentFetchBytes: number;
+  /**
    * If true, expose a Prometheus-compatible `GET /metrics` endpoint on the SSE
    * gateway. Opt-in; ignored when `transport=stdio` (no HTTP listener).
    */
@@ -153,6 +176,10 @@ interface ConfigFile {
   urlAllowlist?: string[];
   allowPrivateUrls?: boolean;
   maxPostBytes?: number;
+  allowLocalFileRead?: boolean;
+  localFileRoots?: string[];
+  contentUrlAllowlist?: string[];
+  maxContentFetchBytes?: number;
   metrics?: boolean;
   metricsAuth?: MetricsAuthMode;
   metricsTokens?: string[];
@@ -180,6 +207,10 @@ interface CliArgs {
   urlAllowlist?: string[];
   allowPrivateUrls?: boolean;
   maxPostBytes?: number;
+  allowLocalFileRead?: boolean;
+  localFileRoots?: string[];
+  contentUrlAllowlist?: string[];
+  maxContentFetchBytes?: number;
   metrics?: boolean;
   metricsAuth?: string;
   metricsTokens?: string[];
@@ -250,6 +281,27 @@ function parseCliArgs(args: string[]): CliArgs {
         if (nextArg) {
           const parsed = parseSize(nextArg);
           if (parsed !== undefined) result.maxPostBytes = parsed;
+        }
+        i++;
+        break;
+      case '--allow-local-file-read':
+        result.allowLocalFileRead = true;
+        break;
+      case '--no-local-file-read':
+        result.allowLocalFileRead = false;
+        break;
+      case '--local-file-roots':
+        result.localFileRoots = splitCsv(nextArg);
+        i++;
+        break;
+      case '--content-url-allowlist':
+        result.contentUrlAllowlist = splitCsv(nextArg);
+        i++;
+        break;
+      case '--max-content-fetch-bytes':
+        if (nextArg) {
+          const parsed = parseSize(nextArg);
+          if (parsed !== undefined) result.maxContentFetchBytes = parsed;
         }
         i++;
         break;
@@ -386,6 +438,19 @@ Multi-tenant HTTP options (require --transport http):
                                      transport. Accepts raw bytes or suffixed values
                                      (e.g. 500mb, 1gb). Default: 500mb.
 
+Content input (file paths / URLs in attachment and image tool inputs):
+  --allow-local-file-read            Permit tool inputs that name local file paths.
+                                     Default: on for stdio, off for --transport http.
+  --no-local-file-read               Disable local file path inputs.
+  --local-file-roots <dirs>          Comma-separated directories content may be read from.
+                                     Empty (default) = unrestricted when reads are allowed.
+  --content-url-allowlist <hosts>    Comma-separated hostnames permitted for http(s) content
+                                     fetches. Empty = any public host (private IPs still
+                                     blocked unless --allow-private-urls).
+  --max-content-fetch-bytes <size>   Max size of a content file read or URL download.
+                                     Accepts raw bytes or suffixed values (e.g. 50mb).
+                                     Default: 50mb.
+
 Metrics (require --transport http):
   --metrics                          Expose Prometheus-compatible GET /metrics on the SSE
                                      gateway. Opt-in; off by default.
@@ -428,6 +493,10 @@ Environment Variables:
   TRILIUM_URL_ALLOWLIST              Comma-separated allowed hostnames for client URLs
   TRILIUM_ALLOW_PRIVATE_URLS         "true" to skip private-IP SSRF guard
   TRILIUM_MAX_POST_BYTES             Max SSE POST body size (raw bytes or e.g. 500mb, 1gb)
+  TRILIUM_ALLOW_LOCAL_FILE_READ      "true"/"false" to permit local file path content inputs
+  TRILIUM_LOCAL_FILE_ROOTS           Comma-separated directories content may be read from
+  TRILIUM_CONTENT_URL_ALLOWLIST      Comma-separated hostnames for http(s) content fetches
+  TRILIUM_MAX_CONTENT_FETCH_BYTES    Max content file read / URL download size (e.g. 50mb)
   TRILIUM_METRICS                    "true" to expose GET /metrics (HTTP transport only)
   TRILIUM_METRICS_AUTH               gateway | bearer | none (default: gateway)
   TRILIUM_METRICS_TOKENS             Comma-separated scrape tokens (for TRILIUM_METRICS_AUTH=bearer)
@@ -481,6 +550,7 @@ function parseBoolean(value: string | undefined): boolean | undefined {
 }
 
 const DEFAULT_MAX_POST_BYTES = 500 * 1024 * 1024;
+const DEFAULT_MAX_CONTENT_FETCH_BYTES = 50 * 1024 * 1024;
 
 /** Accepts a raw byte count or a suffixed value like "500mb", "10MiB", "2g". */
 function parseSize(value: string | undefined): number | undefined {
@@ -516,10 +586,8 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
   // Empty string env vars are treated as unset. Docker compose overrides
   // frequently resolve unset vars to "", and we want those to behave like
   // "not configured" rather than "explicitly empty".
-  const rawUrl =
-    cli.url ?? emptyToUndefined(process.env.TRILIUM_URL) ?? file.url;
-  const rawToken =
-    cli.token ?? emptyToUndefined(process.env.TRILIUM_TOKEN) ?? file.token ?? '';
+  const rawUrl = cli.url ?? emptyToUndefined(process.env.TRILIUM_URL) ?? file.url;
+  const rawToken = cli.token ?? emptyToUndefined(process.env.TRILIUM_TOKEN) ?? file.token ?? '';
 
   const rawPublicUrl =
     cli.publicUrl ?? emptyToUndefined(process.env.TRILIUM_PUBLIC_URL) ?? file.publicUrl;
@@ -535,14 +603,13 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
     3000;
 
   const multiTenant =
-    cli.multiTenant ??
-    parseBoolean(process.env.TRILIUM_MULTI_TENANT) ??
-    file.multiTenant ??
-    false;
+    cli.multiTenant ?? parseBoolean(process.env.TRILIUM_MULTI_TENANT) ?? file.multiTenant ?? false;
 
   const gatewayTokens =
     cli.gatewayTokens ??
-    (process.env.TRILIUM_GATEWAY_TOKENS ? splitCsv(process.env.TRILIUM_GATEWAY_TOKENS) : undefined) ??
+    (process.env.TRILIUM_GATEWAY_TOKENS
+      ? splitCsv(process.env.TRILIUM_GATEWAY_TOKENS)
+      : undefined) ??
     file.gatewayTokens ??
     [];
 
@@ -574,12 +641,45 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
     file.maxPostBytes ??
     DEFAULT_MAX_POST_BYTES;
 
+  // Local file reads default ON for stdio (the operator's own machine) and OFF
+  // for the http transport, where an LLM-supplied path reads the SERVER's
+  // filesystem on behalf of an arbitrary client.
+  const allowLocalFileRead =
+    cli.allowLocalFileRead ??
+    parseBoolean(process.env.TRILIUM_ALLOW_LOCAL_FILE_READ) ??
+    file.allowLocalFileRead ??
+    transport === 'stdio';
+
+  const localFileRoots =
+    cli.localFileRoots ??
+    (process.env.TRILIUM_LOCAL_FILE_ROOTS
+      ? splitCsv(process.env.TRILIUM_LOCAL_FILE_ROOTS)
+      : undefined) ??
+    file.localFileRoots ??
+    [];
+
+  const contentUrlAllowlist =
+    cli.contentUrlAllowlist ??
+    (process.env.TRILIUM_CONTENT_URL_ALLOWLIST
+      ? splitCsv(process.env.TRILIUM_CONTENT_URL_ALLOWLIST)
+      : undefined) ??
+    file.contentUrlAllowlist ??
+    [];
+
+  const maxContentFetchBytes =
+    cli.maxContentFetchBytes ??
+    parseSize(process.env.TRILIUM_MAX_CONTENT_FETCH_BYTES) ??
+    file.maxContentFetchBytes ??
+    DEFAULT_MAX_CONTENT_FETCH_BYTES;
+
   const metricsEnabledRaw =
     cli.metrics ?? parseBoolean(process.env.TRILIUM_METRICS) ?? file.metrics ?? false;
 
   const metricsTokens =
     cli.metricsTokens ??
-    (process.env.TRILIUM_METRICS_TOKENS ? splitCsv(process.env.TRILIUM_METRICS_TOKENS) : undefined) ??
+    (process.env.TRILIUM_METRICS_TOKENS
+      ? splitCsv(process.env.TRILIUM_METRICS_TOKENS)
+      : undefined) ??
     file.metricsTokens ??
     [];
 
@@ -596,10 +696,7 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
     [];
 
   const rateLimitRps =
-    cli.rateLimitRps ??
-    parseNumber(process.env.TRILIUM_RATE_LIMIT_RPS) ??
-    file.rateLimitRps ??
-    0;
+    cli.rateLimitRps ?? parseNumber(process.env.TRILIUM_RATE_LIMIT_RPS) ?? file.rateLimitRps ?? 0;
 
   const rateLimitBurst =
     cli.rateLimitBurst ??
@@ -614,16 +711,10 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
     [];
 
   const jwtJwksUrl =
-    cli.jwtJwksUrl ??
-    emptyToUndefined(process.env.TRILIUM_JWT_JWKS_URL) ??
-    file.jwtJwksUrl ??
-    null;
+    cli.jwtJwksUrl ?? emptyToUndefined(process.env.TRILIUM_JWT_JWKS_URL) ?? file.jwtJwksUrl ?? null;
 
   const jwtIssuer =
-    cli.jwtIssuer ??
-    emptyToUndefined(process.env.TRILIUM_JWT_ISSUER) ??
-    file.jwtIssuer ??
-    null;
+    cli.jwtIssuer ?? emptyToUndefined(process.env.TRILIUM_JWT_ISSUER) ?? file.jwtIssuer ?? null;
 
   const jwtAudience =
     cli.jwtAudience ??
@@ -678,7 +769,9 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
   // (would accept nothing / confuse operators); fail loudly.
   if (gatewayAuth === 'bearer' && gatewayTokens.length === 0) {
     console.error('Error: --gateway-auth bearer requires at least one --gateway-token.');
-    console.error('Either provide a token or pass --gateway-auth none (NOT recommended for multi-tenant).');
+    console.error(
+      'Either provide a token or pass --gateway-auth none (NOT recommended for multi-tenant).'
+    );
     process.exit(1);
   }
 
@@ -700,7 +793,9 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
   }
   if (metricsEnabled && metricsAuth === 'bearer' && metricsTokens.length === 0) {
     console.error('Error: --metrics-auth bearer requires at least one --metrics-token.');
-    console.error('Either provide a scrape token or use --metrics-auth gateway or --metrics-auth none.');
+    console.error(
+      'Either provide a scrape token or use --metrics-auth gateway or --metrics-auth none.'
+    );
     process.exit(1);
   }
   if (metricsEnabled && metricsAuth === 'gateway' && gatewayAuth === 'none') {
@@ -745,6 +840,10 @@ export function loadConfig(args: string[] = process.argv.slice(2)): Config | nul
     urlAllowlist,
     allowPrivateUrls,
     maxPostBytes,
+    allowLocalFileRead,
+    localFileRoots,
+    contentUrlAllowlist,
+    maxContentFetchBytes,
     metricsEnabled,
     metricsAuth,
     metricsTokens,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,6 +1,7 @@
 import { ZodError, type ZodIssue } from 'zod';
 import { TriliumClientError } from '../client/trilium.js';
 import { DiffApplicationError } from '../tools/diff.js';
+import { ContentNormalizationError } from '../tools/contentInput.js';
 
 /**
  * Structured error information for MCP responses
@@ -155,6 +156,18 @@ export function formatDiffError(error: DiffApplicationError): StructuredError {
     message: error.message,
     code: 'DIFF_APPLICATION_FAILED',
     suggestion: 'Fetch the current content and retry with updated diffs.',
+  };
+}
+
+/**
+ * Format a ContentNormalizationError (file path / URL / base64 content input
+ * resolution failure) into a structured error with actionable guidance.
+ */
+export function formatContentInputError(error: ContentNormalizationError): StructuredError {
+  return {
+    message: error.message,
+    code: error.code,
+    suggestion: error.suggestion,
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,10 +8,12 @@ import {
   formatTriliumError,
   formatZodError,
   formatDiffError,
+  formatContentInputError,
   formatUnknownError,
   formatErrorForMCP,
 } from './errors/index.js';
 import { DiffApplicationError } from './tools/diff.js';
+import { configureContentInput, ContentNormalizationError } from './tools/contentInput.js';
 import type { Config } from './config.js';
 import { deriveWebBaseUrl } from './config.js';
 import { SERVER_INSTRUCTIONS } from './server-instructions.js';
@@ -62,14 +64,14 @@ export function buildMcpServer(client: TriliumClient, ctx: McpServerContext): Se
   // Tool order matters: some clients pre-load only the first N tools. Put
   // read-heavy categories first so navigation/search are always available.
   const allTools = [
-    ...registerSearchTools(),       // search_notes, get_note_tree
-    ...registerNoteTools(),          // get_note, get_note_history, create_note, write_note, delete_note
-    ...registerRevisionTools(),      // get_revisions
-    ...registerAttributeTools(),     // get_attributes, set_attribute, delete_attribute
-    ...registerAttachmentTools(),    // get_attachment, create_attachment, write_attachment, delete_attachment
-    ...registerCalendarTools(),      // get_special_note
-    ...registerOrganizationTools(),  // organize_note
-    ...registerSystemTools(),        // create_revision, manage_system
+    ...registerSearchTools(), // search_notes, get_note_tree
+    ...registerNoteTools(), // get_note, get_note_history, create_note, write_note, delete_note
+    ...registerRevisionTools(), // get_revisions
+    ...registerAttributeTools(), // get_attributes, set_attribute, delete_attribute
+    ...registerAttachmentTools(), // get_attachment, create_attachment, write_attachment, delete_attachment
+    ...registerCalendarTools(), // get_special_note
+    ...registerOrganizationTools(), // organize_note
+    ...registerSystemTools(), // create_revision, manage_system
   ];
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -108,13 +110,17 @@ export function buildMcpServer(client: TriliumClient, ctx: McpServerContext): Se
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     const t0 = performance.now();
-    logger.debug('tool_call_args', { session: sessionId, principal, tool: name, args: redactArgs(args) });
+    logger.debug('tool_call_args', {
+      session: sessionId,
+      principal,
+      tool: name,
+      args: redactArgs(args),
+    });
 
     try {
       let result: {
         content: Array<
-          | { type: 'text'; text: string }
-          | { type: 'image'; data: string; mimeType: string }
+          { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
         >;
       } | null = await handleNoteTool(client, name, args);
       if (result !== null) {
@@ -185,6 +191,9 @@ export function buildMcpServer(client: TriliumClient, ctx: McpServerContext): Se
       } else if (error instanceof DiffApplicationError) {
         structured = formatDiffError(error);
         recordToolCall(name, t0, { ok: false, error: 'diff' });
+      } else if (error instanceof ContentNormalizationError) {
+        structured = formatContentInputError(error);
+        recordToolCall(name, t0, { ok: false, error: 'content_input', code: error.code });
       } else {
         structured = formatUnknownError(error);
         recordToolCall(name, t0, {
@@ -217,6 +226,16 @@ async function startStdio(config: Config, logger: Logger): Promise<void> {
 }
 
 export async function createServer(config: Config, logger: Logger): Promise<void> {
+  // Content-input policy is process-wide: both transports share it, and tool
+  // handlers pick it up via the contentInput module rather than a threaded arg.
+  configureContentInput({
+    allowLocalFileRead: config.allowLocalFileRead,
+    localFileRoots: config.localFileRoots,
+    urlGuard: { allowlist: config.contentUrlAllowlist, allowPrivate: config.allowPrivateUrls },
+    maxBytes: config.maxContentFetchBytes,
+    fetchTimeoutMs: 30_000,
+  });
+
   if (config.transport === 'stdio') {
     await startStdio(config, logger);
   } else {

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -5,52 +5,19 @@ import { defineTool } from './schemas.js';
 import { positionSchema, required } from './validators.js';
 import { searchReplaceBlockSchema, resolveContent, verifySearchReplaceResults } from './diff.js';
 import { capWithNotice } from './contentLimits.js';
+import {
+  IMAGE_MIME_TYPES,
+  isImageMimeType,
+  isBinaryMimeType,
+  parseDataUrl,
+  resolveContentInput,
+  ContentNormalizationError,
+  CONTENT_SOURCE_GUIDANCE,
+} from './contentInput.js';
 
-export const IMAGE_MIME_TYPES = new Set([
-  'image/png',
-  'image/jpeg',
-  'image/jpg',
-  'image/gif',
-  'image/webp',
-  'image/svg+xml',
-]);
-
-export function isImageMimeType(mime: string): boolean {
-  return IMAGE_MIME_TYPES.has(mime.toLowerCase());
-}
-
-/**
- * MIME types that TriliumNext treats as text (string) content.
- * Mirrors TriliumNext's isStringNote() logic in services/utils.ts.
- */
-const TEXT_MIME_EXACT = new Set([
-  'application/javascript',
-  'application/x-javascript',
-  'application/json',
-  'application/x-sql',
-  'image/svg+xml',
-]);
-
-export function isBinaryMimeType(mime: string): boolean {
-  const lower = mime.toLowerCase();
-  if (lower.startsWith('text/')) return false;
-  if (TEXT_MIME_EXACT.has(lower)) return false;
-  return true;
-}
-
-export function base64ToBuffer(base64: string): Buffer {
-  return Buffer.from(base64, 'base64');
-}
-
-/**
- * Parse a data URL (data:mime;base64,content) and extract the MIME type and base64 content.
- * Returns null if the string is not a data URL.
- */
-export function parseDataUrl(data: string): { mime: string; base64: string } | null {
-  const match = data.match(/^data:([^;]+);base64,(.+)$/s);
-  if (!match) return null;
-  return { mime: match[1], base64: match[2] };
-}
+// The MIME helpers moved to contentInput.ts (which this module depends on);
+// re-export them so existing importers keep working.
+export { IMAGE_MIME_TYPES, isImageMimeType, isBinaryMimeType, parseDataUrl };
 
 // ============================================================================
 // Schemas
@@ -67,16 +34,21 @@ const createAttachmentSchema = z.object({
     .describe('Role of the attachment (e.g., "file", "image")'),
   mime: z
     .string()
-    .min(1, 'MIME type is required')
-    .describe('MIME type of the attachment (e.g., "image/png", "application/pdf")'),
-  title: z.string().min(1, 'Title is required').describe('Title/filename of the attachment'),
-  content: z
-    .string()
+    .min(1)
+    .optional()
     .describe(
-      'Content of the attachment. For binary MIME types: base64 or a data URL ' +
-        "(data:image/png;base64,...) — a data URL's MIME type overrides the mime field. " +
-        'For text MIME types: the raw string.'
+      'Optional MIME type (e.g., "image/png", "application/pdf") — auto-detected from a data URL, ' +
+        'magic bytes, or file extension. Set only to override detection.'
     ),
+  title: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Title/filename of the attachment. Optional when content is a file path or URL ' +
+        '(defaults to its basename); required for inline content.'
+    ),
+  content: z.string().describe(`Content of the attachment. ${CONTENT_SOURCE_GUIDANCE}`),
   position: positionSchema.optional().describe('Position for ordering (10, 20, 30...)'),
 });
 
@@ -137,7 +109,7 @@ const writeAttachmentSchema = z
       .describe(
         'Write mode. ' +
           '"metadata" — update role/mime/title/position only. ' +
-          '"replace" — overwrite attachment content (base64 or a data URL for binary MIME types). ' +
+          '"replace" — overwrite attachment content (accepts a file path, http(s) URL, data URL, base64, or raw text). ' +
           '"edit" — apply search/replace blocks (changes) or a unified diff (patch) to existing text content.'
       ),
     role: z.string().optional().describe('New role (metadata mode only).'),
@@ -147,9 +119,7 @@ const writeAttachmentSchema = z
     content: z
       .string()
       .optional()
-      .describe(
-        'New content for "replace" mode. For binary MIME types, provide base64-encoded data or a data URL (data:...;base64,...).'
-      ),
+      .describe(`New content for "replace" mode. ${CONTENT_SOURCE_GUIDANCE}`),
     changes: z
       .array(searchReplaceBlockSchema)
       .optional()
@@ -248,9 +218,10 @@ export function registerAttachmentTools(): Tool[] {
     defineTool(
       'create_attachment',
       'Create a new attachment on a note. Returns the created attachment metadata. ' +
-        'For binary MIME types (images, PDFs, most file types), provide content as base64-encoded data ' +
-        "or a data URL (data:image/png;base64,...) — a data URL's MIME type overrides the mime field. " +
-        'For text MIME types (text/*, application/json, application/javascript), provide content as a raw string.',
+        `${CONTENT_SOURCE_GUIDANCE} ` +
+        'mime and title are optional — auto-detected/derived from the source ' +
+        '(magic bytes, data-URL header, or file extension); a path or URL basename becomes the title. ' +
+        'Simplest call: {ownerId, role: "image", content: "/tmp/screenshot.png"}.',
       createAttachmentSchema,
       {
         title: 'Create attachment',
@@ -263,7 +234,8 @@ export function registerAttachmentTools(): Tool[] {
       'write_attachment',
       'Update an attachment. Three modes via "mode":\n' +
         '- "metadata": update role/mime/title/position (no content change)\n' +
-        '- "replace": overwrite the attachment body (base64 for binary MIME types)\n' +
+        '- "replace": overwrite the attachment body — accepts a local file path, http(s) URL, ' +
+        'data URL, base64 (binary types), or raw text (text types); the stored mime is kept\n' +
         '- "edit": apply "changes" (search/replace blocks) or "patch" (unified diff) to existing text content\n\n' +
         '"edit" mode only works for text content — it fetches existing content, applies the diff, and verifies the result.',
       writeAttachmentSchema,
@@ -304,34 +276,38 @@ export async function handleAttachmentTool(
   switch (name) {
     case 'create_attachment': {
       const parsed = createAttachmentSchema.parse(args);
-      // A data URL's MIME type overrides the explicit mime field (same
-      // convention as the images/files params on create_note/write_note).
-      const dataUrl = parseDataUrl(parsed.content);
-      const mime = dataUrl ? dataUrl.mime : parsed.mime;
-      if (isBinaryMimeType(mime)) {
+      const resolved = await resolveContentInput(parsed.content, {
+        mime: parsed.mime,
+        filename: parsed.title,
+      });
+      const title = parsed.title ?? resolved.sourceName;
+      if (!title) {
+        throw new ContentNormalizationError(
+          'UNDETECTABLE_MIME',
+          'A title is required when the content source has no filename (inline base64 or raw text).',
+          'Provide a title (e.g. "screenshot.png"), or pass a file path or URL whose basename can serve as one.'
+        );
+      }
+      if (resolved.isBinary) {
         const result = await client.createAttachment({
           ownerId: parsed.ownerId,
           role: parsed.role,
-          mime,
-          title: parsed.title,
+          mime: resolved.mime,
+          title,
           content: '',
           position: parsed.position,
         });
-        const binaryContent = base64ToBuffer(dataUrl ? dataUrl.base64 : parsed.content);
-        await client.updateAttachmentContentBinary(result.attachmentId, binaryContent);
+        await client.updateAttachmentContentBinary(result.attachmentId, resolved.buffer);
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       }
-      const textContent = dataUrl
-        ? Buffer.from(dataUrl.base64, 'base64').toString('utf8')
-        : parsed.content;
       const result = await client.createAttachment({
         ownerId: parsed.ownerId,
         role: parsed.role,
-        mime,
-        title: parsed.title,
-        content: textContent,
+        mime: resolved.mime,
+        title,
+        content: resolved.buffer.toString('utf8'),
         position: parsed.position,
       });
       return {
@@ -399,15 +375,19 @@ export async function handleAttachmentTool(
       if (parsed.mode === 'replace') {
         const content = required(parsed.content, 'content');
         const attachment = await client.getAttachment(parsed.attachmentId);
-        const dataUrl = parseDataUrl(content);
+        // The stored mime is the hint: replace never silently re-types the
+        // attachment (metadata mode does that).
+        const resolved = await resolveContentInput(content, {
+          mime: attachment.mime,
+          filename: attachment.title,
+        });
         if (isBinaryMimeType(attachment.mime)) {
-          const binaryContent = base64ToBuffer(dataUrl ? dataUrl.base64 : content);
-          await client.updateAttachmentContentBinary(parsed.attachmentId, binaryContent);
+          await client.updateAttachmentContentBinary(parsed.attachmentId, resolved.buffer);
         } else {
-          const textContent = dataUrl
-            ? Buffer.from(dataUrl.base64, 'base64').toString('utf8')
-            : content;
-          await client.updateAttachmentContent(parsed.attachmentId, textContent);
+          await client.updateAttachmentContent(
+            parsed.attachmentId,
+            resolved.buffer.toString('utf8')
+          );
         }
         return {
           content: [

--- a/src/tools/contentInput.ts
+++ b/src/tools/contentInput.ts
@@ -1,0 +1,626 @@
+import { promises as fs } from 'node:fs';
+import { isUtf8 } from 'node:buffer';
+import { homedir } from 'node:os';
+import { basename, isAbsolute, join, sep } from 'node:path';
+import { fileTypeFromBuffer } from 'file-type';
+import { assertUrlIsSafe, UrlGuardError } from '../http/urlGuard.js';
+
+// ============================================================================
+// MIME helpers (moved here from attachments.ts so both attachments.ts and
+// notes.ts can import them without a cycle; attachments.ts re-exports them)
+// ============================================================================
+
+export const IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+]);
+
+export function isImageMimeType(mime: string): boolean {
+  return IMAGE_MIME_TYPES.has(mime.toLowerCase());
+}
+
+/**
+ * MIME types that TriliumNext treats as text (string) content.
+ * Mirrors TriliumNext's isStringNote() logic in services/utils.ts.
+ */
+const TEXT_MIME_EXACT = new Set([
+  'application/javascript',
+  'application/x-javascript',
+  'application/json',
+  'application/x-sql',
+  'image/svg+xml',
+]);
+
+export function isBinaryMimeType(mime: string): boolean {
+  const lower = mime.toLowerCase();
+  if (lower.startsWith('text/')) return false;
+  if (TEXT_MIME_EXACT.has(lower)) return false;
+  return true;
+}
+
+/**
+ * Shared schema-description text for every content-carrying field. This is the
+ * LLM's UX for the feature — keep it in sync with resolveContentInput.
+ */
+export const CONTENT_SOURCE_GUIDANCE =
+  'Pass any of: a local file path ("/abs/path" or "~/path"), an http(s) URL, a data URL ' +
+  '(data:image/png;base64,...), or inline base64 (binary types) / raw text (text types) — ' +
+  'the source is auto-detected. Use a file:// prefix to force path interpretation.';
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+export type ContentNormalizationCode =
+  | 'PATH_NOT_FOUND'
+  | 'PATH_NOT_PERMITTED'
+  | 'INPUT_TOO_LARGE'
+  | 'URL_BLOCKED'
+  | 'URL_FETCH_FAILED'
+  | 'INVALID_BASE64'
+  | 'UNDETECTABLE_MIME';
+
+export class ContentNormalizationError extends Error {
+  constructor(
+    public readonly code: ContentNormalizationCode,
+    message: string,
+    public readonly suggestion: string
+  ) {
+    super(message);
+    this.name = 'ContentNormalizationError';
+  }
+}
+
+// ============================================================================
+// Low-level parsers
+// ============================================================================
+
+/**
+ * Strict base64 decoder. Returns null when the input is not valid base64
+ * (Buffer.from(x, 'base64') silently skips invalid characters, which turns
+ * typos into corrupted uploads). Whitespace is tolerated — LLMs often wrap
+ * long base64 payloads.
+ */
+export function decodeBase64Strict(input: string): Buffer | null {
+  const cleaned = input.replace(/\s+/g, '');
+  if (cleaned.length % 4 !== 0) return null;
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(cleaned)) return null;
+  return Buffer.from(cleaned, 'base64');
+}
+
+/**
+ * Parse a data URL and extract the MIME type and decoded bytes. Handles both
+ * the base64 form (data:image/png;base64,...) and the percent-encoded text
+ * form (data:text/plain,hello%20world). Returns null if the string is not a
+ * data URL; throws INVALID_BASE64 if it is one but its payload is corrupt.
+ */
+export function parseDataUrl(data: string): { mime: string; buffer: Buffer } | null {
+  const match = data.match(/^data:([^,]*),([\s\S]*)$/);
+  if (!match) return null;
+  let mediatype = match[1];
+  const payload = match[2];
+
+  let isBase64 = false;
+  if (/;base64$/i.test(mediatype)) {
+    isBase64 = true;
+    mediatype = mediatype.replace(/;base64$/i, '');
+  }
+  // Strip parameters (charset=...) and default per RFC 2397.
+  const mime = mediatype.split(';')[0].trim() || 'text/plain';
+
+  if (isBase64) {
+    const buffer = decodeBase64Strict(payload);
+    if (buffer === null) {
+      throw new ContentNormalizationError(
+        'INVALID_BASE64',
+        'The data URL payload is not valid base64.',
+        'Re-encode the content as base64, or pass a file path or http(s) URL instead.'
+      );
+    }
+    return { mime, buffer };
+  }
+
+  let text: string;
+  try {
+    text = decodeURIComponent(payload);
+  } catch {
+    text = payload;
+  }
+  return { mime, buffer: Buffer.from(text, 'utf8') };
+}
+
+// ============================================================================
+// Policy
+// ============================================================================
+
+export interface ContentInputPolicy {
+  /** Permit reading LLM-supplied local file paths. */
+  allowLocalFileRead: boolean;
+  /** When non-empty, restrict path reads to these directories (realpath-checked). */
+  localFileRoots: string[];
+  /** SSRF guard options for http(s) content fetches. */
+  urlGuard: { allowlist: string[]; allowPrivate: boolean };
+  /** Maximum bytes for any file read or URL download. */
+  maxBytes: number;
+  /** Timeout for each URL fetch request. */
+  fetchTimeoutMs: number;
+}
+
+const DEFAULT_POLICY: ContentInputPolicy = {
+  allowLocalFileRead: true,
+  localFileRoots: [],
+  urlGuard: { allowlist: [], allowPrivate: false },
+  maxBytes: 50 * 1024 * 1024,
+  fetchTimeoutMs: 30_000,
+};
+
+let activePolicy: ContentInputPolicy = DEFAULT_POLICY;
+
+/** Set the process-wide content-input policy. Called once at server startup. */
+export function configureContentInput(policy: ContentInputPolicy): void {
+  activePolicy = policy;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export type ContentOrigin = 'inline-text' | 'inline-base64' | 'data-url' | 'path' | 'url';
+
+export interface ResolvedContent {
+  buffer: Buffer;
+  mime: string;
+  isBinary: boolean;
+  origin: ContentOrigin;
+  /** Basename of the source path/URL, usable as a default filename/title. */
+  sourceName?: string;
+}
+
+export interface ContentHints {
+  /** Explicit caller-provided MIME type; beats sniffing (but not a data-URL header). */
+  mime?: string;
+  /** Filename whose extension helps MIME resolution. */
+  filename?: string;
+}
+
+/**
+ * Resolve LLM-supplied content in any supported form — data URL, http(s) URL,
+ * local file path (absolute, `~/`, or `file://`), inline base64, or raw text —
+ * into bytes plus a resolved MIME type.
+ *
+ * Detection precedence: data: > http(s):// > file:// > existing absolute path >
+ * inline. Path detection is verification-gated: a string only counts as a path
+ * if it is short (≤1024 chars) AND names an existing regular file, so base64
+ * payloads (JPEG base64 starts with "/9j/4AAQ...") and prose can never be
+ * misread as paths.
+ */
+export async function resolveContentInput(
+  raw: string,
+  hints: ContentHints = {},
+  policyOverride?: ContentInputPolicy
+): Promise<ResolvedContent> {
+  const policy = policyOverride ?? activePolicy;
+
+  // 1. Data URL — unambiguous prefix.
+  if (raw.startsWith('data:')) {
+    const parsed = parseDataUrl(raw);
+    if (parsed) {
+      return finalize(parsed.buffer, 'data-url', { hints, resolvedMime: parsed.mime });
+    }
+  }
+
+  // 2. http(s) URL — unambiguous prefix, must parse and contain no whitespace.
+  if (/^https?:\/\//i.test(raw) && !/\s/.test(raw)) {
+    const url = tryParseUrl(raw);
+    if (url) return await fetchFromUrl(url, hints, policy);
+  }
+
+  // 3. file:// — the explicit "this is a path" discriminator: no fallthrough.
+  if (raw.startsWith('file://')) {
+    return await readFromPath(raw.slice('file://'.length), hints, policy, { explicit: true });
+  }
+
+  // 4. Plausible local path, verification-gated. The length cap and the
+  //    stat-existence check below make base64 false-positives impossible:
+  //    JPEG base64 starts with "/9j/4AAQ..." but is far longer than 1024
+  //    chars for any real image, and never names an existing file.
+  let pathCandidate: string | null = null;
+  if (raw.length <= 1024 && /^(~\/|\/)[^\n\0]*$/.test(raw)) {
+    const expanded = expandTilde(raw);
+    const stats = await fs.stat(expanded).catch(() => null);
+    if (stats?.isFile()) {
+      return await readFromPath(raw, hints, policy, { explicit: false });
+    }
+    pathCandidate = raw;
+  }
+
+  // 5. Inline content (today's behavior, mime-driven).
+  return await resolveInline(raw, hints, pathCandidate);
+}
+
+// ============================================================================
+// Path reading
+// ============================================================================
+
+function expandTilde(path: string): string {
+  return path.startsWith('~/') ? join(homedir(), path.slice(2)) : path;
+}
+
+async function readFromPath(
+  rawPath: string,
+  hints: ContentHints,
+  policy: ContentInputPolicy,
+  opts: { explicit: boolean }
+): Promise<ResolvedContent> {
+  if (!policy.allowLocalFileRead) {
+    throw new ContentNormalizationError(
+      'PATH_NOT_PERMITTED',
+      `Local file reads are disabled on this server (input: ${rawPath}).`,
+      'Pass the content inline as base64 or a data URL, use an http(s) URL, or start the server with --allow-local-file-read.'
+    );
+  }
+
+  const expanded = expandTilde(rawPath);
+  if (!isAbsolute(expanded)) {
+    throw new ContentNormalizationError(
+      'PATH_NOT_FOUND',
+      `File paths must be absolute or start with ~/ (got: ${rawPath}).`,
+      'Use an absolute path like /tmp/image.png or ~/Documents/image.png.'
+    );
+  }
+
+  // Resolve symlinks BEFORE the roots check so a link inside an allowed root
+  // cannot point outside the sandbox.
+  let real: string;
+  try {
+    real = await fs.realpath(expanded);
+  } catch {
+    throw new ContentNormalizationError(
+      'PATH_NOT_FOUND',
+      `The input looks like a file path but no such file exists: ${rawPath}`,
+      opts.explicit
+        ? 'Check the path, or pass the content inline as base64, a data URL, or an http(s) URL.'
+        : 'Check the path. If this string was meant as literal content, provide an explicit mime.'
+    );
+  }
+
+  if (policy.localFileRoots.length > 0) {
+    const roots = await Promise.all(
+      policy.localFileRoots.map((r) => fs.realpath(expandTilde(r)).catch(() => null))
+    );
+    const inRoot = roots.some(
+      (root) =>
+        root !== null && (real === root || real.startsWith(root.endsWith(sep) ? root : root + sep))
+    );
+    if (!inRoot) {
+      throw new ContentNormalizationError(
+        'PATH_NOT_PERMITTED',
+        `Path is outside the directories this server may read from: ${rawPath}`,
+        'Pass the content inline as base64 or a data URL, or adjust --local-file-roots.'
+      );
+    }
+  }
+
+  const stats = await fs.stat(real);
+  if (!stats.isFile()) {
+    throw new ContentNormalizationError(
+      'PATH_NOT_FOUND',
+      `Path exists but is not a regular file: ${rawPath}`,
+      'Point at a file, not a directory or special file.'
+    );
+  }
+  if (stats.size > policy.maxBytes) {
+    throw new ContentNormalizationError(
+      'INPUT_TOO_LARGE',
+      `File is ${stats.size} bytes; the limit is ${policy.maxBytes} bytes: ${rawPath}`,
+      'Reduce the file size or raise --max-content-fetch-bytes.'
+    );
+  }
+
+  const buffer = await fs.readFile(real);
+  return finalize(buffer, 'path', { hints, sourceName: basename(expanded) });
+}
+
+// ============================================================================
+// URL fetching
+// ============================================================================
+
+const MAX_REDIRECTS = 3;
+
+function tryParseUrl(raw: string): URL | null {
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch with manual, re-guarded redirects; returns the final OK response. */
+async function fetchGuarded(
+  url: URL,
+  policy: ContentInputPolicy
+): Promise<{ response: Response; finalUrl: URL }> {
+  let current = url;
+
+  for (let redirects = 0; ; redirects++) {
+    // Re-guard EVERY hop so a public URL cannot redirect us into a private
+    // network or cloud metadata endpoint. (Known DNS TOCTOU between guard and
+    // fetch — same accepted trade-off as the X-Trilium-Url guard.)
+    try {
+      await assertUrlIsSafe(current.href, policy.urlGuard);
+    } catch (err) {
+      if (err instanceof UrlGuardError) {
+        throw new ContentNormalizationError(
+          'URL_BLOCKED',
+          `URL rejected (${err.reason}): ${current.href} — ${err.message}`,
+          'Use a public URL, add the host to --content-url-allowlist, or (for private/homelab hosts) start the server with --allow-private-urls.'
+        );
+      }
+      throw err;
+    }
+
+    let resp: Response;
+    try {
+      resp = await fetch(current.href, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(policy.fetchTimeoutMs),
+      });
+    } catch (err) {
+      throw new ContentNormalizationError(
+        'URL_FETCH_FAILED',
+        `Could not fetch ${current.href}: ${err instanceof Error ? err.message : String(err)}`,
+        'Check the URL is reachable from the server, or download the file and pass a local path or base64.'
+      );
+    }
+
+    if (resp.status >= 300 && resp.status < 400) {
+      const location = resp.headers.get('location');
+      await resp.body?.cancel().catch(() => {});
+      if (!location) {
+        throw new ContentNormalizationError(
+          'URL_FETCH_FAILED',
+          `Redirect from ${current.href} had no Location header.`,
+          'Check the URL, or download the file and pass a local path or base64.'
+        );
+      }
+      if (redirects >= MAX_REDIRECTS) {
+        throw new ContentNormalizationError(
+          'URL_FETCH_FAILED',
+          `Too many redirects fetching ${url.href}.`,
+          'Use the final URL directly.'
+        );
+      }
+      current = new URL(location, current);
+      continue;
+    }
+
+    if (!resp.ok) {
+      await resp.body?.cancel().catch(() => {});
+      throw new ContentNormalizationError(
+        'URL_FETCH_FAILED',
+        `HTTP ${resp.status} fetching ${current.href}.`,
+        'Check the URL, or download the file and pass a local path or base64.'
+      );
+    }
+
+    return { response: resp, finalUrl: current };
+  }
+}
+
+async function fetchFromUrl(
+  url: URL,
+  hints: ContentHints,
+  policy: ContentInputPolicy
+): Promise<ResolvedContent> {
+  const { response, finalUrl } = await fetchGuarded(url, policy);
+
+  const declaredLength = response.headers.get('content-length');
+  if (declaredLength && Number(declaredLength) > policy.maxBytes) {
+    await response.body?.cancel().catch(() => {});
+    throw new ContentNormalizationError(
+      'INPUT_TOO_LARGE',
+      `Remote content is ${declaredLength} bytes; the limit is ${policy.maxBytes} bytes: ${finalUrl.href}`,
+      'Fetch a smaller resource or raise --max-content-fetch-bytes.'
+    );
+  }
+
+  // Stream with a byte counter — Content-Length can lie or be absent.
+  const chunks: Buffer[] = [];
+  let total = 0;
+  if (response.body) {
+    const reader = response.body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > policy.maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new ContentNormalizationError(
+          'INPUT_TOO_LARGE',
+          `Download exceeded the ${policy.maxBytes}-byte limit: ${finalUrl.href}`,
+          'Fetch a smaller resource or raise --max-content-fetch-bytes.'
+        );
+      }
+      chunks.push(Buffer.from(value));
+    }
+  }
+  const buffer = Buffer.concat(chunks);
+
+  const contentType = response.headers.get('content-type')?.split(';')[0].trim().toLowerCase();
+  const pathBase = basename(url.pathname);
+  return finalize(buffer, 'url', {
+    hints,
+    sourceName: pathBase && pathBase !== '/' ? pathBase : undefined,
+    transportMime: contentType || undefined,
+  });
+}
+
+// ============================================================================
+// Inline content
+// ============================================================================
+
+async function resolveInline(
+  raw: string,
+  hints: ContentHints,
+  pathCandidate: string | null
+): Promise<ResolvedContent> {
+  const pathOrBase64Error = (): ContentNormalizationError => {
+    if (pathCandidate) {
+      return new ContentNormalizationError(
+        'PATH_NOT_FOUND',
+        `The input looks like a file path but no such file exists: ${pathCandidate}`,
+        'Check the path, or pass the content inline as base64, a data URL, or an http(s) URL.'
+      );
+    }
+    return new ContentNormalizationError(
+      'INVALID_BASE64',
+      'Content for a binary MIME type must be valid base64 (or a file path, data URL, or http(s) URL).',
+      'Re-encode the content as base64, or pass a file path or URL instead.'
+    );
+  };
+
+  if (hints.mime) {
+    if (isBinaryMimeType(hints.mime)) {
+      const buffer = decodeBase64Strict(raw);
+      if (buffer === null) throw pathOrBase64Error();
+      return {
+        buffer,
+        mime: hints.mime,
+        isBinary: true,
+        origin: 'inline-base64',
+      };
+    }
+    return {
+      buffer: Buffer.from(raw, 'utf8'),
+      mime: hints.mime,
+      isBinary: false,
+      origin: 'inline-text',
+    };
+  }
+
+  // No mime given. Only treat the input as binary when a magic-byte sniff
+  // POSITIVELY identifies it — short prose can be coincidentally valid base64,
+  // and decoding it silently would store garbage.
+  const decoded = decodeBase64Strict(raw);
+  if (decoded && decoded.length > 0) {
+    const sniffed = await fileTypeFromBuffer(decoded);
+    if (sniffed) {
+      return {
+        buffer: decoded,
+        mime: sniffed.mime,
+        isBinary: isBinaryMimeType(sniffed.mime),
+        origin: 'inline-base64',
+      };
+    }
+  }
+
+  const extMime = mimeFromExtension(hints.filename);
+  if (extMime) {
+    if (isBinaryMimeType(extMime)) {
+      if (decoded === null) throw pathOrBase64Error();
+      return { buffer: decoded, mime: extMime, isBinary: true, origin: 'inline-base64' };
+    }
+    return {
+      buffer: Buffer.from(raw, 'utf8'),
+      mime: extMime,
+      isBinary: false,
+      origin: 'inline-text',
+    };
+  }
+
+  if (pathCandidate) throw pathOrBase64Error();
+  throw new ContentNormalizationError(
+    'UNDETECTABLE_MIME',
+    'Could not determine the content type of the inline input.',
+    'Provide a mime (e.g. "text/plain"), a filename with a known extension, or pass the content as a data URL, file path, or http(s) URL.'
+  );
+}
+
+// ============================================================================
+// MIME resolution
+// ============================================================================
+
+/**
+ * Small internal extension→MIME map for types file-type cannot sniff
+ * (text formats and SVG). Binary formats are covered by magic bytes.
+ */
+const EXTENSION_MIME: Record<string, string> = {
+  svg: 'image/svg+xml',
+  txt: 'text/plain',
+  log: 'text/plain',
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  csv: 'text/csv',
+  tsv: 'text/tab-separated-values',
+  json: 'application/json',
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  js: 'application/javascript',
+  mjs: 'application/javascript',
+  cjs: 'application/javascript',
+  ts: 'text/plain',
+  xml: 'text/xml',
+  yaml: 'text/yaml',
+  yml: 'text/yaml',
+  sql: 'application/x-sql',
+  py: 'text/plain',
+  sh: 'text/plain',
+  ini: 'text/plain',
+  toml: 'text/plain',
+};
+
+function mimeFromExtension(filename: string | undefined): string | undefined {
+  if (!filename) return undefined;
+  const dot = filename.lastIndexOf('.');
+  if (dot === -1 || dot === filename.length - 1) return undefined;
+  return EXTENSION_MIME[filename.slice(dot + 1).toLowerCase()];
+}
+
+function looksLikeSvg(buffer: Buffer): boolean {
+  const head = buffer.subarray(0, 512).toString('utf8').trimStart();
+  return head.startsWith('<svg') || (head.startsWith('<?xml') && head.includes('<svg'));
+}
+
+/**
+ * Resolve the final MIME for bytes fetched from a data URL, path, or URL.
+ * Order: data-URL header (passed as resolvedMime) > explicit hint > magic-byte
+ * sniff > SVG heuristic > HTTP Content-Type (below the sniff — servers
+ * misconfigure) > extension map > UTF-8/octet-stream fallback.
+ */
+async function finalize(
+  buffer: Buffer,
+  origin: ContentOrigin,
+  opts: {
+    hints: ContentHints;
+    resolvedMime?: string;
+    transportMime?: string;
+    sourceName?: string;
+  }
+): Promise<ResolvedContent> {
+  let mime = opts.resolvedMime ?? opts.hints.mime;
+  if (!mime) {
+    const sniffed = await fileTypeFromBuffer(buffer);
+    if (sniffed) mime = sniffed.mime;
+  }
+  if (!mime && looksLikeSvg(buffer)) mime = 'image/svg+xml';
+  if (!mime && opts.transportMime) mime = opts.transportMime;
+  if (!mime) mime = mimeFromExtension(opts.hints.filename ?? opts.sourceName);
+  if (!mime) {
+    // These bytes came from a real source the caller clearly intended to
+    // upload — never fail, fall back to text or an opaque blob.
+    mime = isUtf8(buffer) ? 'text/plain' : 'application/octet-stream';
+  }
+
+  return {
+    buffer,
+    mime,
+    isBinary: isBinaryMimeType(mime),
+    origin,
+    sourceName: opts.sourceName,
+  };
+}

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -12,45 +12,38 @@ import {
 } from './validators.js';
 import { marked } from 'marked';
 import TurndownService from 'turndown';
-import { isImageMimeType, isBinaryMimeType, base64ToBuffer, parseDataUrl } from './attachments.js';
+import {
+  isImageMimeType,
+  isBinaryMimeType,
+  resolveContentInput,
+  CONTENT_SOURCE_GUIDANCE,
+} from './contentInput.js';
 import { searchReplaceBlockSchema, resolveContent, verifySearchReplaceResults } from './diff.js';
 import { CONTENT_CHAR_CAP } from './contentLimits.js';
 
-/**
- * Resolve the data field: if it's a data URL, extract base64 + mime (overriding explicit mime).
- * If it's raw base64, return as-is with the explicit mime.
- */
-function resolveAttachmentData(entry: { data: string; mime: string }): {
-  data: string;
-  mime: string;
-} {
-  const parsed = parseDataUrl(entry.data);
-  if (parsed) {
-    return { data: parsed.base64, mime: parsed.mime };
-  }
-  return { data: entry.data, mime: entry.mime };
-}
-
 const imageEntrySchema = z.object({
-  data: z
-    .string()
-    .describe(
-      'Image data as base64 string or data URL (data:image/png;base64,...). ' +
-        'When using a data URL, the MIME type is extracted automatically and overrides the mime field.'
-    ),
+  data: z.string().describe(`The image. ${CONTENT_SOURCE_GUIDANCE}`),
   mime: z
     .string()
+    .optional()
     .describe(
-      'MIME type of the image (e.g., "image/png", "image/jpeg"). Ignored if data is a data URL.'
+      'Optional MIME type (e.g., "image/png") — auto-detected from the source; set only to override.'
     ),
-  filename: z.string().describe('Filename for the image attachment (e.g., "screenshot.png")'),
+  filename: z
+    .string()
+    .optional()
+    .describe(
+      'Optional filename for the image attachment (e.g., "screenshot.png"). ' +
+        'Defaults to the path/URL basename, else image-N.'
+    ),
 });
 
 const imagesFieldSchema = z
   .array(imageEntrySchema)
   .optional()
   .describe(
-    'Optional array of images to embed in the note. The data field accepts raw base64 or a data URL (data:image/png;base64,...). ' +
+    'Optional array of images to embed in the note. The data field accepts a local file path, an http(s) URL, ' +
+      'a data URL, or raw base64 — auto-detected; mime and filename are optional. ' +
       'Reference images in your content using placeholder URLs: in markdown use ![alt](image:0), ![alt](image:1), etc. ' +
       'In HTML use <img src="image:0"> (double quotes required). The number is the zero-based index into THIS array — ' +
       'placeholders do NOT reference attachments uploaded in earlier calls. Images and placeholders must be provided together in the same call. ' +
@@ -63,24 +56,43 @@ const imagesFieldSchema = z
  * Placeholders use the format src="image:N" where N is the zero-based index.
  * Images not referenced by a placeholder are appended at the end of the content.
  */
+/** Extensions for default attachment names, keyed by resolved MIME. */
+const MIME_EXTENSION: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'application/pdf': 'pdf',
+};
+
+function defaultAttachmentName(prefix: string, index: number, mime: string): string {
+  const ext = MIME_EXTENSION[mime.toLowerCase()];
+  return ext ? `${prefix}-${index}.${ext}` : `${prefix}-${index}`;
+}
+
 async function processImages(
   client: TriliumClient,
   ownerId: string,
   htmlContent: string,
-  images: Array<{ data: string; mime: string; filename: string }>
+  images: Array<{ data: string; mime?: string; filename?: string }>
 ): Promise<string> {
   const attachments = await Promise.all(
-    images.map(async (img) => {
-      const resolved = resolveAttachmentData(img);
+    images.map(async (img, i) => {
+      const resolved = await resolveContentInput(img.data, {
+        mime: img.mime,
+        filename: img.filename,
+      });
+      const title =
+        img.filename ?? resolved.sourceName ?? defaultAttachmentName('image', i, resolved.mime);
       const attachment = await client.createAttachment({
         ownerId,
         role: 'image',
         mime: resolved.mime,
-        title: img.filename,
+        title,
         content: '',
       });
-      const binaryContent = base64ToBuffer(resolved.data);
-      await client.updateAttachmentContentBinary(attachment.attachmentId, binaryContent);
+      await client.updateAttachmentContentBinary(attachment.attachmentId, resolved.buffer);
       return attachment;
     })
   );
@@ -110,25 +122,29 @@ async function processImages(
 }
 
 const fileEntrySchema = z.object({
-  data: z
-    .string()
-    .describe(
-      'File data as base64 string or data URL (data:application/pdf;base64,...). ' +
-        'When using a data URL, the MIME type is extracted automatically and overrides the mime field.'
-    ),
+  data: z.string().describe(`The file. ${CONTENT_SOURCE_GUIDANCE}`),
   mime: z
     .string()
+    .optional()
     .describe(
-      'MIME type of the file (e.g., "application/pdf", "text/csv"). Ignored if data is a data URL.'
+      'Optional MIME type (e.g., "application/pdf", "text/csv") — auto-detected from the source; ' +
+        'set only to override.'
     ),
-  filename: z.string().describe('Filename for the file attachment (e.g., "report.pdf")'),
+  filename: z
+    .string()
+    .optional()
+    .describe(
+      'Optional filename for the file attachment (e.g., "report.pdf"). ' +
+        'Defaults to the path/URL basename, else file-N.'
+    ),
 });
 
 const filesFieldSchema = z
   .array(fileEntrySchema)
   .optional()
   .describe(
-    'Optional array of files to attach and embed as download links in the note. The data field accepts raw base64 or a data URL. ' +
+    'Optional array of files to attach and embed as download links in the note. The data field accepts a local file path, ' +
+      'an http(s) URL, a data URL, raw base64 (binary types), or raw text (text types) — auto-detected; mime and filename are optional. ' +
       'Reference files in your content using placeholder URLs: in markdown use [label](file:0), [label](file:1), etc. ' +
       'In HTML use <a href="file:0">label</a> (double quotes required). The number is the zero-based index into THIS array — ' +
       'placeholders do NOT reference attachments uploaded in earlier calls. Files and placeholders must be provided together in the same call. ' +
@@ -143,29 +159,33 @@ async function processFiles(
   client: TriliumClient,
   ownerId: string,
   htmlContent: string,
-  files: Array<{ data: string; mime: string; filename: string }>
+  files: Array<{ data: string; mime?: string; filename?: string }>
 ): Promise<string> {
   const attachments = await Promise.all(
-    files.map(async (file) => {
-      const resolved = resolveAttachmentData(file);
-      if (isBinaryMimeType(resolved.mime)) {
+    files.map(async (file, i) => {
+      const resolved = await resolveContentInput(file.data, {
+        mime: file.mime,
+        filename: file.filename,
+      });
+      const title =
+        file.filename ?? resolved.sourceName ?? defaultAttachmentName('file', i, resolved.mime);
+      if (resolved.isBinary) {
         const attachment = await client.createAttachment({
           ownerId,
           role: 'file',
           mime: resolved.mime,
-          title: file.filename,
+          title,
           content: '',
         });
-        const binaryContent = base64ToBuffer(resolved.data);
-        await client.updateAttachmentContentBinary(attachment.attachmentId, binaryContent);
+        await client.updateAttachmentContentBinary(attachment.attachmentId, resolved.buffer);
         return attachment;
       }
       return client.createAttachment({
         ownerId,
         role: 'file',
         mime: resolved.mime,
-        title: file.filename,
-        content: resolved.data,
+        title,
+        content: resolved.buffer.toString('utf8'),
       });
     })
   );
@@ -266,6 +286,8 @@ const createNoteSchema = z.object({
     .describe(
       'Content of the note. For text notes: provide HTML (default) or markdown (if format is "markdown"). ' +
         'For code notes: provide raw code. ' +
+        'For binary notes (file/image types with a binary mime): provide base64, a data URL, ' +
+        'a local file path, or an http(s) URL — auto-detected. ' +
         'For code blocks in HTML, use <pre><code class="language-X">...</code></pre> structure ' +
         '(e.g., language-mermaid, language-javascript). The class must be on the <code> element, not <pre>. ' +
         INTERNAL_LINK_GUIDANCE
@@ -607,8 +629,18 @@ export async function handleNoteTool(
   switch (name) {
     case 'create_note': {
       const parsed = createNoteSchema.parse(args);
-      let content = await convertContent(parsed.content, parsed.format);
       const isBinary = parsed.mime ? isBinaryMimeType(parsed.mime) : false;
+      // Binary content is normalized BEFORE any format conversion — running
+      // markdown conversion on a base64 string would corrupt it.
+      const binaryContent = isBinary
+        ? (
+            await resolveContentInput(parsed.content, {
+              mime: parsed.mime,
+              filename: parsed.title,
+            })
+          ).buffer
+        : null;
+      let content = isBinary ? '' : await convertContent(parsed.content, parsed.format);
       const hasAttachments =
         (parsed.images && parsed.images.length > 0) || (parsed.files && parsed.files.length > 0);
       if (!isBinary && !hasAttachments) {
@@ -629,8 +661,7 @@ export async function handleNoteTool(
         utcDateCreated: parsed.utcDateCreated,
       });
 
-      if (isBinary && content) {
-        const binaryContent = base64ToBuffer(content);
+      if (binaryContent && binaryContent.length > 0) {
         await client.updateNoteContentBinary(result.note.noteId, binaryContent);
       }
 
@@ -642,7 +673,11 @@ export async function handleNoteTool(
           content = await processFiles(client, result.note.noteId, content, parsed.files);
         }
         assertPlaceholdersResolved(content);
-        await client.updateNoteContent(result.note.noteId, content);
+        // For a binary note the body IS the binary blob — writing the
+        // placeholder HTML would overwrite it.
+        if (!isBinary) {
+          await client.updateNoteContent(result.note.noteId, content);
+        }
       }
 
       const url = await client.getNoteUrl(result.note.noteId, result.branch.parentNoteId);

--- a/tests/integration/etapi.test.ts
+++ b/tests/integration/etapi.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
+import { tmpdir, homedir } from 'node:os';
+import { join, basename } from 'node:path';
+import type { AddressInfo } from 'node:net';
 import { fileTypeFromBuffer } from 'file-type';
+import { configureContentInput } from '../../src/tools/contentInput.js';
 import { TriliumClient, TriliumClientError } from '../../src/client/trilium.js';
 import { handleNoteTool } from '../../src/tools/notes.js';
 import { handleAttachmentTool } from '../../src/tools/attachments.js';
@@ -2030,6 +2036,152 @@ This has <angle brackets> and "quotes" & ampersands.
       const tags = refreshed.attributes.filter((a) => a.name === 'tag');
       expect(tags).toHaveLength(2);
       expect(tags.map((t) => t.value).sort()).toEqual(['first', 'second']);
+    });
+  });
+
+  // ==========================================================================
+  // Content input normalization: file paths, URLs, optional mime/filename.
+  // The example payload shapes here are quoted in README.md ("Providing file
+  // content") — keep them in sync (docs examples must be test-validated).
+  // ==========================================================================
+  describe('Content input normalization (paths, URLs, optional mime)', () => {
+    const pngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    const pngBytes = Buffer.from(pngBase64, 'base64');
+
+    let tempDir: string;
+    let fixtureServer: HttpServer;
+    let fixtureOrigin: string;
+
+    beforeAll(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'trilium-mcp-int-'));
+      // The fixture server lives on 127.0.0.1, which the default policy blocks
+      // (SSRF guard). Open private URLs for this suite only.
+      configureContentInput({
+        allowLocalFileRead: true,
+        localFileRoots: [],
+        urlGuard: { allowlist: [], allowPrivate: true },
+        maxBytes: 50 * 1024 * 1024,
+        fetchTimeoutMs: 10_000,
+      });
+      fixtureOrigin = await new Promise<string>((resolve) => {
+        fixtureServer = createHttpServer((req, res) => {
+          res.writeHead(200);
+          res.end(pngBytes);
+        });
+        fixtureServer.listen(0, '127.0.0.1', () => {
+          const { port } = fixtureServer.address() as AddressInfo;
+          resolve(`http://127.0.0.1:${port}`);
+        });
+      });
+    });
+
+    afterAll(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+      await new Promise<void>((r) => fixtureServer.close(() => r()));
+      configureContentInput({
+        allowLocalFileRead: true,
+        localFileRoots: [],
+        urlGuard: { allowlist: [], allowPrivate: false },
+        maxBytes: 50 * 1024 * 1024,
+        fetchTimeoutMs: 30_000,
+      });
+    });
+
+    it('create_note with an image given only as a file path round-trips byte-identically', async () => {
+      const imagePath = join(tempDir, 'from-disk.png');
+      await writeFile(imagePath, pngBytes);
+
+      const result = await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'Image From Disk',
+        type: 'text',
+        content: '<p>Look:</p><img src="image:0">',
+        images: [{ data: imagePath }],
+      });
+      const noteId = JSON.parse(result!.content[0].text as string).note.noteId;
+
+      const attachments = await client.getNoteAttachments(noteId);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].mime).toBe('image/png');
+      expect(attachments[0].title).toBe('from-disk.png');
+
+      const content = await client.getNoteContent(noteId);
+      expect(content).toContain('/image/from-disk.png');
+      expect(content).not.toContain('image:0');
+
+      // Byte-identical round trip: what Trilium stores must sniff as a real PNG.
+      const stored = await client.getAttachmentContentAsBase64(attachments[0].attachmentId);
+      expect(Buffer.from(stored, 'base64').equals(pngBytes)).toBe(true);
+    });
+
+    it('create_attachment from a ~/ path derives mime and title', async () => {
+      const homeTempDir = await mkdtemp(join(homedir(), '.trilium-mcp-int-'));
+      try {
+        await writeFile(join(homeTempDir, 'tilde.png'), pngBytes);
+        const note = await client.createNote({
+          parentNoteId: 'root',
+          title: 'Tilde Path Owner',
+          type: 'text',
+          content: '<p>owner</p>',
+        });
+        const tildePath = `~/${basename(homeTempDir)}/tilde.png`;
+
+        const result = await handleAttachmentTool(client, 'create_attachment', {
+          ownerId: note.note.noteId,
+          role: 'image',
+          content: tildePath,
+        });
+        const created = JSON.parse(result!.content[0].text as string);
+        expect(created.mime).toBe('image/png');
+        expect(created.title).toBe('tilde.png');
+
+        const stored = await client.getAttachmentContentAsBase64(created.attachmentId);
+        expect(Buffer.from(stored, 'base64').equals(pngBytes)).toBe(true);
+      } finally {
+        await rm(homeTempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('create_note with an image fetched from a URL', async () => {
+      const result = await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'Image From URL',
+        type: 'text',
+        content: '<p>Remote:</p>',
+        images: [{ data: `${fixtureOrigin}/remote-pixel.png` }],
+      });
+      const noteId = JSON.parse(result!.content[0].text as string).note.noteId;
+
+      const attachments = await client.getNoteAttachments(noteId);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].mime).toBe('image/png');
+      expect(attachments[0].title).toBe('remote-pixel.png');
+
+      const stored = await client.getAttachmentContentAsBase64(attachments[0].attachmentId);
+      expect(Buffer.from(stored, 'base64').equals(pngBytes)).toBe(true);
+    });
+
+    it('create_note files[] reads a text file from a path into a text attachment', async () => {
+      const csvPath = join(tempDir, 'stats.csv');
+      await writeFile(csvPath, 'name,count\nalpha,1\n');
+
+      const result = await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'CSV From Disk',
+        type: 'text',
+        content: '<p>Data: <a href="file:0">stats</a></p>',
+        files: [{ data: csvPath }],
+      });
+      const noteId = JSON.parse(result!.content[0].text as string).note.noteId;
+
+      const attachments = await client.getNoteAttachments(noteId);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].mime).toBe('text/csv');
+      expect(attachments[0].title).toBe('stats.csv');
+
+      const stored = await client.getAttachmentContent(attachments[0].attachmentId);
+      expect(stored).toBe('name,count\nalpha,1\n');
     });
   });
 });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -509,3 +509,92 @@ describe('normalizeServerUrl', () => {
     expect(normalizeServerUrl('http://localhost/trilium')).toBe('http://localhost/trilium/etapi');
   });
 });
+
+describe('content input policy config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const key of [
+      'TRILIUM_URL',
+      'TRILIUM_TOKEN',
+      'TRILIUM_TRANSPORT',
+      'TRILIUM_MULTI_TENANT',
+      'TRILIUM_GATEWAY_AUTH',
+      'TRILIUM_GATEWAY_TOKENS',
+      'TRILIUM_ALLOW_LOCAL_FILE_READ',
+      'TRILIUM_LOCAL_FILE_ROOTS',
+      'TRILIUM_CONTENT_URL_ALLOWLIST',
+      'TRILIUM_MAX_CONTENT_FETCH_BYTES',
+    ]) {
+      delete process.env[key];
+    }
+    process.env.TRILIUM_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults: local reads allowed on stdio, no roots, no URL allowlist, 50 MB cap', () => {
+    const config = loadConfig([]);
+    expect(config!.allowLocalFileRead).toBe(true);
+    expect(config!.localFileRoots).toEqual([]);
+    expect(config!.contentUrlAllowlist).toEqual([]);
+    expect(config!.maxContentFetchBytes).toBe(50 * 1024 * 1024);
+  });
+
+  it('defaults local reads OFF for the http transport', () => {
+    const config = loadConfig(['--transport', 'http']);
+    expect(config!.allowLocalFileRead).toBe(false);
+  });
+
+  it('--allow-local-file-read overrides the http default', () => {
+    const config = loadConfig(['--transport', 'http', '--allow-local-file-read']);
+    expect(config!.allowLocalFileRead).toBe(true);
+  });
+
+  it('--no-local-file-read overrides the stdio default', () => {
+    const config = loadConfig(['--no-local-file-read']);
+    expect(config!.allowLocalFileRead).toBe(false);
+  });
+
+  it('TRILIUM_ALLOW_LOCAL_FILE_READ env var is honored', () => {
+    process.env.TRILIUM_ALLOW_LOCAL_FILE_READ = 'false';
+    const config = loadConfig([]);
+    expect(config!.allowLocalFileRead).toBe(false);
+  });
+
+  it('--local-file-roots parses a CSV list', () => {
+    const config = loadConfig(['--local-file-roots', '/tmp, /home/user/uploads']);
+    expect(config!.localFileRoots).toEqual(['/tmp', '/home/user/uploads']);
+  });
+
+  it('TRILIUM_LOCAL_FILE_ROOTS env var is honored', () => {
+    process.env.TRILIUM_LOCAL_FILE_ROOTS = '/srv/data';
+    const config = loadConfig([]);
+    expect(config!.localFileRoots).toEqual(['/srv/data']);
+  });
+
+  it('--content-url-allowlist parses a CSV list', () => {
+    const config = loadConfig(['--content-url-allowlist', 'example.com,cdn.example.org']);
+    expect(config!.contentUrlAllowlist).toEqual(['example.com', 'cdn.example.org']);
+  });
+
+  it('TRILIUM_CONTENT_URL_ALLOWLIST env var is honored', () => {
+    process.env.TRILIUM_CONTENT_URL_ALLOWLIST = 'files.example.net';
+    const config = loadConfig([]);
+    expect(config!.contentUrlAllowlist).toEqual(['files.example.net']);
+  });
+
+  it('--max-content-fetch-bytes accepts suffixed sizes', () => {
+    const config = loadConfig(['--max-content-fetch-bytes', '10mb']);
+    expect(config!.maxContentFetchBytes).toBe(10 * 1024 * 1024);
+  });
+
+  it('TRILIUM_MAX_CONTENT_FETCH_BYTES env var is honored', () => {
+    process.env.TRILIUM_MAX_CONTENT_FETCH_BYTES = '1mb';
+    const config = loadConfig([]);
+    expect(config!.maxContentFetchBytes).toBe(1024 * 1024);
+  });
+});

--- a/tests/unit/contentInput.test.ts
+++ b/tests/unit/contentInput.test.ts
@@ -1,0 +1,508 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm, symlink } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir, homedir } from 'node:os';
+import { join, basename } from 'node:path';
+import type { AddressInfo } from 'node:net';
+import {
+  resolveContentInput,
+  ContentNormalizationError,
+  parseDataUrl,
+  decodeBase64Strict,
+  type ContentInputPolicy,
+} from '../../src/tools/contentInput.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal valid PNG: signature + IHDR (1x1) + IEND. file-type sniffs it as image/png. */
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // signature
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR length + type
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1x1
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, // bit depth, color, CRC
+  0x89,
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, // IEND
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+/** JPEG header — its base64 starts with "/9j/", the classic path-lookalike. */
+const JPEG_BYTES = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+]);
+
+const PNG_B64 = PNG_BYTES.toString('base64');
+const JPEG_B64 = JPEG_BYTES.toString('base64');
+
+/** Permissive stdio-like policy for tests; individual tests override fields. */
+function policy(overrides: Partial<ContentInputPolicy> = {}): ContentInputPolicy {
+  return {
+    allowLocalFileRead: true,
+    localFileRoots: [],
+    urlGuard: { allowlist: [], allowPrivate: true },
+    maxBytes: 50 * 1024 * 1024,
+    fetchTimeoutMs: 5000,
+    ...overrides,
+  };
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+async function makeTempDir(base = tmpdir()): Promise<string> {
+  const dir = await mkdtemp(join(base, 'trilium-mcp-ci-'));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+async function makeTempFile(name: string, content: Buffer | string, base?: string) {
+  const dir = await makeTempDir(base);
+  const path = join(dir, name);
+  await writeFile(path, content);
+  return { dir, path };
+}
+
+function startServer(
+  handler: Parameters<typeof createServer>[1]
+): Promise<{ server: Server; origin: string }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      cleanups.push(() => new Promise((r) => server.close(() => r())));
+      resolve({ server, origin: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function expectError(
+  promise: Promise<unknown>,
+  code: string
+): Promise<ContentNormalizationError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(ContentNormalizationError);
+    expect((err as ContentNormalizationError).code).toBe(code);
+    return err as ContentNormalizationError;
+  }
+  throw new Error(`expected ContentNormalizationError(${code}) but nothing was thrown`);
+}
+
+// ---------------------------------------------------------------------------
+// parseDataUrl
+// ---------------------------------------------------------------------------
+
+describe('parseDataUrl', () => {
+  it('parses the base64 form', () => {
+    const parsed = parseDataUrl(`data:image/png;base64,${PNG_B64}`);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.mime).toBe('image/png');
+    expect(parsed!.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('parses the non-base64 percent-encoded form', () => {
+    const parsed = parseDataUrl('data:text/plain,hello%20world');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.mime).toBe('text/plain');
+    expect(parsed!.buffer.toString('utf8')).toBe('hello world');
+  });
+
+  it('defaults the mime to text/plain when omitted', () => {
+    const parsed = parseDataUrl('data:,hi');
+    expect(parsed!.mime).toBe('text/plain');
+    expect(parsed!.buffer.toString('utf8')).toBe('hi');
+  });
+
+  it('strips mediatype parameters like charset', () => {
+    const parsed = parseDataUrl('data:text/plain;charset=utf-8,hi');
+    expect(parsed!.mime).toBe('text/plain');
+  });
+
+  it('returns null for non-data-URL strings', () => {
+    expect(parseDataUrl('hello')).toBeNull();
+    expect(parseDataUrl('/tmp/foo.png')).toBeNull();
+    expect(parseDataUrl('https://example.com/a.png')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decodeBase64Strict
+// ---------------------------------------------------------------------------
+
+describe('decodeBase64Strict', () => {
+  it('decodes valid base64', () => {
+    expect(decodeBase64Strict(PNG_B64)!.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('tolerates whitespace and newlines (common in LLM output)', () => {
+    const wrapped = PNG_B64.replace(/(.{20})/g, '$1\n');
+    expect(decodeBase64Strict(wrapped)!.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('returns null for invalid characters', () => {
+    expect(decodeBase64Strict('not valid base64!!!')).toBeNull();
+  });
+
+  it('returns null for wrong padding length', () => {
+    expect(decodeBase64Strict('abcde')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline content (backward-compatible paths)
+// ---------------------------------------------------------------------------
+
+describe('resolveContentInput: inline', () => {
+  it('decodes base64 when mime is binary (today’s behavior)', async () => {
+    const res = await resolveContentInput(PNG_B64, { mime: 'image/png' }, policy());
+    expect(res.origin).toBe('inline-base64');
+    expect(res.mime).toBe('image/png');
+    expect(res.isBinary).toBe(true);
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('treats JPEG base64 starting with /9j/ as base64, never as a path', async () => {
+    const res = await resolveContentInput(JPEG_B64, { mime: 'image/jpeg' }, policy());
+    expect(res.origin).toBe('inline-base64');
+    expect(res.buffer.equals(JPEG_BYTES)).toBe(true);
+  });
+
+  it('keeps raw text verbatim for text mimes, even when it looks like base64', async () => {
+    const prose = 'Deadbeef'; // valid base64 alphabet, but text mime means verbatim
+    const res = await resolveContentInput(prose, { mime: 'text/plain' }, policy());
+    expect(res.origin).toBe('inline-text');
+    expect(res.isBinary).toBe(false);
+    expect(res.buffer.toString('utf8')).toBe(prose);
+  });
+
+  it('keeps path-shaped raw text verbatim for text mimes when no such file exists', async () => {
+    const prose = '/etc/some/path/mentioned/in/a/note.txt';
+    const res = await resolveContentInput(prose, { mime: 'text/plain' }, policy());
+    expect(res.origin).toBe('inline-text');
+    expect(res.buffer.toString('utf8')).toBe(prose);
+  });
+
+  it('rejects invalid base64 for binary mimes instead of silently corrupting', async () => {
+    await expectError(
+      resolveContentInput('this is definitely not base64!!!', { mime: 'image/png' }, policy()),
+      'INVALID_BASE64'
+    );
+  });
+
+  it('sniffs binary type from base64 when no mime is given', async () => {
+    const res = await resolveContentInput(PNG_B64, {}, policy());
+    expect(res.origin).toBe('inline-base64');
+    expect(res.mime).toBe('image/png');
+  });
+
+  it('resolves text mime from the filename extension when no mime is given', async () => {
+    const res = await resolveContentInput('a,b\n1,2\n', { filename: 'data.csv' }, policy());
+    expect(res.origin).toBe('inline-text');
+    expect(res.mime).toBe('text/csv');
+    expect(res.buffer.toString('utf8')).toBe('a,b\n1,2\n');
+  });
+
+  it('errors on undetectable inline input with no mime (no text/plain guess)', async () => {
+    await expectError(
+      resolveContentInput('hello world, this is prose', {}, policy()),
+      'UNDETECTABLE_MIME'
+    );
+  });
+
+  it('errors on base64-decodable but unsniffable input with no mime', async () => {
+    // "abcd1234" is valid base64 but decodes to unidentifiable bytes — must not
+    // silently store garbage as a binary blob.
+    await expectError(resolveContentInput('abcd1234', {}, policy()), 'UNDETECTABLE_MIME');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data URLs
+// ---------------------------------------------------------------------------
+
+describe('resolveContentInput: data URLs', () => {
+  it('extracts bytes and mime, overriding the explicit mime hint', async () => {
+    const res = await resolveContentInput(
+      `data:image/png;base64,${PNG_B64}`,
+      { mime: 'image/jpeg' },
+      policy()
+    );
+    expect(res.origin).toBe('data-url');
+    expect(res.mime).toBe('image/png');
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('supports the non-base64 form', async () => {
+    const res = await resolveContentInput('data:text/plain,hello%20world', {}, policy());
+    expect(res.origin).toBe('data-url');
+    expect(res.mime).toBe('text/plain');
+    expect(res.isBinary).toBe(false);
+    expect(res.buffer.toString('utf8')).toBe('hello world');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local file paths
+// ---------------------------------------------------------------------------
+
+describe('resolveContentInput: local paths', () => {
+  it('reads an absolute path and sniffs the mime from magic bytes', async () => {
+    const { path } = await makeTempFile('shot.png', PNG_BYTES);
+    const res = await resolveContentInput(path, {}, policy());
+    expect(res.origin).toBe('path');
+    expect(res.mime).toBe('image/png');
+    expect(res.isBinary).toBe(true);
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+    expect(res.sourceName).toBe('shot.png');
+  });
+
+  it('sniff beats a misleading file extension', async () => {
+    const { path } = await makeTempFile('actually-a-png.txt', PNG_BYTES);
+    const res = await resolveContentInput(path, {}, policy());
+    expect(res.mime).toBe('image/png');
+  });
+
+  it('an explicit mime hint beats the sniff', async () => {
+    const { path } = await makeTempFile('img.png', PNG_BYTES);
+    const res = await resolveContentInput(path, { mime: 'image/webp' }, policy());
+    expect(res.mime).toBe('image/webp');
+  });
+
+  it('reads a text file (text mime resolution via extension)', async () => {
+    const { path } = await makeTempFile('data.csv', 'a,b\n1,2\n');
+    const res = await resolveContentInput(path, {}, policy());
+    expect(res.origin).toBe('path');
+    expect(res.mime).toBe('text/csv');
+    expect(res.isBinary).toBe(false);
+    expect(res.buffer.toString('utf8')).toBe('a,b\n1,2\n');
+  });
+
+  it('detects SVG content as image/svg+xml (file-type cannot sniff SVG)', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
+    const { path } = await makeTempFile('icon.svg', svg);
+    const res = await resolveContentInput(path, {}, policy());
+    expect(res.mime).toBe('image/svg+xml');
+    expect(res.isBinary).toBe(false); // Trilium stores SVG as text
+  });
+
+  it('falls back to text/plain for extension-less UTF-8 text files', async () => {
+    const { path } = await makeTempFile('README', 'just some notes\n');
+    const res = await resolveContentInput(path, {}, policy());
+    expect(res.mime).toBe('text/plain');
+  });
+
+  it('falls back to application/octet-stream for unidentifiable binary files', async () => {
+    const { path } = await makeTempFile('mystery.bin', Buffer.from([0x00, 0x01, 0xfe, 0xff, 0x80]));
+    const res = await resolveContentInput(path, {}, policy());
+    expect(res.mime).toBe('application/octet-stream');
+    expect(res.isBinary).toBe(true);
+  });
+
+  it('supports the file:// prefix as an explicit path discriminator', async () => {
+    const { path } = await makeTempFile('shot.png', PNG_BYTES);
+    const res = await resolveContentInput(`file://${path}`, {}, policy());
+    expect(res.origin).toBe('path');
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('file:// with a nonexistent path fails with PATH_NOT_FOUND (no fallthrough)', async () => {
+    await expectError(
+      resolveContentInput('file:///nonexistent/nope.png', {}, policy()),
+      'PATH_NOT_FOUND'
+    );
+  });
+
+  it('expands ~/ against the home directory', async () => {
+    const dir = await makeTempDir(homedir());
+    const path = join(dir, 'home.png');
+    await writeFile(path, PNG_BYTES);
+    const tilde = `~/${join(basename(dir), 'home.png')}`;
+    const res = await resolveContentInput(tilde, {}, policy());
+    expect(res.origin).toBe('path');
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('mentions the path when path-shaped binary input does not exist on disk', async () => {
+    const err = await expectError(
+      resolveContentInput('/nonexistent/dir/shot.png', { mime: 'image/png' }, policy()),
+      'PATH_NOT_FOUND'
+    );
+    expect(err.message).toContain('/nonexistent/dir/shot.png');
+  });
+
+  it('refuses path reads when allowLocalFileRead is false', async () => {
+    const { path } = await makeTempFile('secret.png', PNG_BYTES);
+    await expectError(
+      resolveContentInput(path, {}, policy({ allowLocalFileRead: false })),
+      'PATH_NOT_PERMITTED'
+    );
+  });
+
+  it('refuses paths outside localFileRoots', async () => {
+    const root = await makeTempDir();
+    const { path: outside } = await makeTempFile('out.png', PNG_BYTES);
+    await expectError(
+      resolveContentInput(outside, {}, policy({ localFileRoots: [root] })),
+      'PATH_NOT_PERMITTED'
+    );
+  });
+
+  it('allows paths inside localFileRoots', async () => {
+    const root = await makeTempDir();
+    const path = join(root, 'in.png');
+    await writeFile(path, PNG_BYTES);
+    const res = await resolveContentInput(path, {}, policy({ localFileRoots: [root] }));
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('resolves symlinks before the root check so links cannot escape the sandbox', async () => {
+    const root = await makeTempDir();
+    const { path: outside } = await makeTempFile('target.png', PNG_BYTES);
+    const link = join(root, 'sneaky.png');
+    await symlink(outside, link);
+    await expectError(
+      resolveContentInput(link, {}, policy({ localFileRoots: [root] })),
+      'PATH_NOT_PERMITTED'
+    );
+  });
+
+  it('rejects files larger than maxBytes', async () => {
+    const { path } = await makeTempFile('big.bin', Buffer.alloc(2048));
+    await expectError(
+      resolveContentInput(path, {}, policy({ maxBytes: 1024 })),
+      'INPUT_TOO_LARGE'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URLs
+// ---------------------------------------------------------------------------
+
+describe('resolveContentInput: URLs', () => {
+  it('fetches bytes and sniffs the mime', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      res.end(PNG_BYTES);
+    });
+    const res = await resolveContentInput(`${origin}/img.png?v=2`, {}, policy());
+    expect(res.origin).toBe('url');
+    expect(res.mime).toBe('image/png');
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+    expect(res.sourceName).toBe('img.png');
+  });
+
+  it('sniff beats a wrong Content-Type header', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(PNG_BYTES);
+    });
+    const res = await resolveContentInput(`${origin}/x`, {}, policy());
+    expect(res.mime).toBe('image/png');
+  });
+
+  it('uses the response Content-Type when sniffing fails', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/csv; charset=utf-8' });
+      res.end('a,b\n1,2\n');
+    });
+    const res = await resolveContentInput(`${origin}/export`, {}, policy());
+    expect(res.mime).toBe('text/csv');
+    expect(res.isBinary).toBe(false);
+  });
+
+  it('follows redirects, re-guarding each hop', async () => {
+    const { origin } = await startServer((req, res) => {
+      if (req.url === '/start') {
+        res.writeHead(302, { Location: `${origin}/final.png` });
+        res.end();
+      } else {
+        res.writeHead(200);
+        res.end(PNG_BYTES);
+      }
+    });
+    const res = await resolveContentInput(`${origin}/start`, {}, policy());
+    expect(res.buffer.equals(PNG_BYTES)).toBe(true);
+  });
+
+  it('blocks a redirect to a host outside the allowlist', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(302, { Location: 'http://127.0.0.2:9/steal' });
+      res.end();
+    });
+    await expectError(
+      resolveContentInput(
+        `${origin}/start`,
+        {},
+        policy({ urlGuard: { allowlist: ['127.0.0.1'], allowPrivate: false } })
+      ),
+      'URL_BLOCKED'
+    );
+  });
+
+  it('blocks private hosts when allowPrivate is false', async () => {
+    await expectError(
+      resolveContentInput(
+        'http://127.0.0.1:1/x.png',
+        {},
+        policy({ urlGuard: { allowlist: [], allowPrivate: false } })
+      ),
+      'URL_BLOCKED'
+    );
+  });
+
+  it('fails on non-2xx responses', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(404);
+      res.end('nope');
+    });
+    await expectError(resolveContentInput(`${origin}/missing.png`, {}, policy()), 'URL_FETCH_FAILED');
+  });
+
+  it('fails after too many redirects', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(302, { Location: `${origin}/loop` });
+      res.end();
+    });
+    await expectError(resolveContentInput(`${origin}/loop`, {}, policy()), 'URL_FETCH_FAILED');
+  });
+
+  it('rejects oversized downloads via Content-Length up front', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Length': String(10 * 1024) });
+      res.end(Buffer.alloc(10 * 1024));
+    });
+    await expectError(
+      resolveContentInput(`${origin}/big.bin`, {}, policy({ maxBytes: 1024 })),
+      'INPUT_TOO_LARGE'
+    );
+  });
+
+  it('aborts oversized chunked downloads that hide their length', async () => {
+    const { origin } = await startServer((req, res) => {
+      // No Content-Length -> chunked; stream forever-ish
+      res.writeHead(200);
+      const chunk = Buffer.alloc(1024);
+      for (let i = 0; i < 64; i++) res.write(chunk);
+      res.end();
+    });
+    await expectError(
+      resolveContentInput(`${origin}/stream.bin`, {}, policy({ maxBytes: 4 * 1024 })),
+      'INPUT_TOO_LARGE'
+    );
+  });
+
+  it('an explicit mime hint beats everything for URLs too', async () => {
+    const { origin } = await startServer((req, res) => {
+      res.writeHead(200);
+      res.end(PNG_BYTES);
+    });
+    const res = await resolveContentInput(`${origin}/img`, { mime: 'image/webp' }, policy());
+    expect(res.mime).toBe('image/webp');
+  });
+});

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -5,9 +5,11 @@ import {
   formatTriliumError,
   formatZodError,
   formatUnknownError,
+  formatContentInputError,
   formatErrorForMCP,
   type StructuredError,
 } from '../../src/errors/index.js';
+import { ContentNormalizationError } from '../../src/tools/contentInput.js';
 
 describe('Error Formatting', () => {
   describe('formatTriliumError', () => {
@@ -252,5 +254,27 @@ describe('Error Formatting', () => {
       expect(text).toContain('field1');
       expect(text).toContain('field2');
     });
+  });
+});
+
+describe('formatContentInputError', () => {
+  it('carries the code and suggestion through to the structured error', () => {
+    const err = new ContentNormalizationError(
+      'PATH_NOT_FOUND',
+      'The input looks like a file path but no such file exists: /tmp/nope.png',
+      'Check the path.'
+    );
+    const structured = formatContentInputError(err);
+    expect(structured.message).toContain('/tmp/nope.png');
+    expect(structured.code).toBe('PATH_NOT_FOUND');
+    expect(structured.suggestion).toBe('Check the path.');
+  });
+
+  it('renders through formatErrorForMCP with a Suggestion block', () => {
+    const err = new ContentNormalizationError('URL_BLOCKED', 'URL rejected.', 'Use a public URL.');
+    const mcp = formatErrorForMCP(formatContentInputError(err));
+    expect(mcp.isError).toBe(true);
+    expect(mcp.content[0].text).toContain('**Code**: URL_BLOCKED');
+    expect(mcp.content[0].text).toContain('**Suggestion**: Use a public URL.');
   });
 });

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -353,3 +353,19 @@ describe('createLogger — env-driven defaults', () => {
     }
   });
 });
+
+describe('redactArgs: content-input fields', () => {
+  it('never logs attachment/image content, whatever form it arrived in', () => {
+    const out = redactArgs({
+      ownerId: 'n1',
+      content: '/tmp/secret-report.png',
+      images: [{ data: 'iVBORw0KGgo...', mime: 'image/png' }],
+      files: [{ data: '~/docs/x.csv' }],
+    }) as Record<string, unknown>;
+    expect(out.content).toBe('<string len=22>');
+    expect(out.images).toBe('<array len=1>');
+    expect(out.files).toBe('<array len=1>');
+    expect(JSON.stringify(out)).not.toContain('iVBORw0KGgo');
+    expect(JSON.stringify(out)).not.toContain('secret-report');
+  });
+});

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { createServer as createHttpServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { configureContentInput } from '../../src/tools/contentInput.js';
 import { registerNoteTools, handleNoteTool } from '../../src/tools/notes.js';
 import { registerSearchTools, handleSearchTool } from '../../src/tools/search.js';
 import { registerOrganizationTools, handleOrganizationTool } from '../../src/tools/organization.js';
@@ -1930,5 +1935,294 @@ describe('Total tool surface', () => {
       const props = tool!.inputSchema.properties as Record<string, { default?: unknown }>;
       expect(props[param].default, `${toolName}.${param}`).toBe(expected);
     }
+  });
+});
+
+// ============================================================================
+// Content input normalization in handlers (file paths / URLs / optional mime)
+// ============================================================================
+
+describe('content input normalization in handlers', () => {
+  const PNG_BYTES = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89,
+    0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+    0xae, 0x42, 0x60, 0x82,
+  ]);
+
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    while (cleanups.length) await cleanups.pop()!();
+    // Restore the module-level default policy so other suites are unaffected.
+    configureContentInput({
+      allowLocalFileRead: true,
+      localFileRoots: [],
+      urlGuard: { allowlist: [], allowPrivate: false },
+      maxBytes: 50 * 1024 * 1024,
+      fetchTimeoutMs: 30_000,
+    });
+  });
+
+  beforeEach(() => {
+    client = createMockClient({
+      createNote: vi.fn().mockResolvedValue({
+        note: { noteId: 'n1' },
+        branch: { parentNoteId: 'root' },
+      }),
+      createAttachment: vi
+        .fn()
+        .mockImplementation((args: { title: string }) =>
+          Promise.resolve({ attachmentId: 'a1', title: args.title })
+        ),
+    });
+    configureContentInput({
+      allowLocalFileRead: true,
+      localFileRoots: [],
+      urlGuard: { allowlist: [], allowPrivate: true },
+      maxBytes: 50 * 1024 * 1024,
+      fetchTimeoutMs: 5000,
+    });
+  });
+
+  let client: TriliumClient;
+
+  async function makePng(name = 'shot.png'): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'trilium-mcp-handler-'));
+    cleanups.push(() => rm(dir, { recursive: true, force: true }));
+    const path = join(dir, name);
+    await writeFile(path, PNG_BYTES);
+    return path;
+  }
+
+  describe('create_attachment', () => {
+    it('accepts a file path with no mime and no title — everything is inferred', async () => {
+      const path = await makePng();
+      await handleAttachmentTool(client, 'create_attachment', {
+        ownerId: 'n1',
+        role: 'image',
+        content: path,
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ mime: 'image/png', title: 'shot.png' })
+      );
+      const sent = (client.updateAttachmentContentBinary as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+      expect(sent.equals(PNG_BYTES)).toBe(true);
+    });
+
+    it('keeps an explicit title over the path basename', async () => {
+      const path = await makePng();
+      await handleAttachmentTool(client, 'create_attachment', {
+        ownerId: 'n1',
+        role: 'image',
+        title: 'Cover image',
+        content: path,
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Cover image' })
+      );
+    });
+
+    it('fails with PATH_NOT_FOUND when a path-shaped binary input does not exist', async () => {
+      await expect(
+        handleAttachmentTool(client, 'create_attachment', {
+          ownerId: 'n1',
+          role: 'image',
+          mime: 'image/png',
+          title: 'x.png',
+          content: '/nonexistent/dir/shot.png',
+        })
+      ).rejects.toMatchObject({ code: 'PATH_NOT_FOUND' });
+    });
+
+    it('resolves a text mime from the title extension when mime is omitted', async () => {
+      await handleAttachmentTool(client, 'create_attachment', {
+        ownerId: 'n1',
+        role: 'file',
+        title: 'readme.txt',
+        content: 'plain notes here',
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ mime: 'text/plain', content: 'plain notes here' })
+      );
+      expect(client.updateAttachmentContentBinary).not.toHaveBeenCalled();
+    });
+
+    it('errors with UNDETECTABLE_MIME for prose with no mime and no useful extension', async () => {
+      await expect(
+        handleAttachmentTool(client, 'create_attachment', {
+          ownerId: 'n1',
+          role: 'file',
+          title: 'notes',
+          content: 'some prose that could be anything',
+        })
+      ).rejects.toMatchObject({ code: 'UNDETECTABLE_MIME' });
+    });
+
+    it('requires a title when none can be derived from the source', async () => {
+      await expect(
+        handleAttachmentTool(client, 'create_attachment', {
+          ownerId: 'n1',
+          role: 'image',
+          content: PNG_BYTES.toString('base64'),
+        })
+      ).rejects.toThrow(/title/i);
+    });
+
+    it('fetches content from a URL', async () => {
+      const { origin } = await new Promise<{ origin: string }>((resolve) => {
+        const server = createHttpServer((req, res) => {
+          res.writeHead(200);
+          res.end(PNG_BYTES);
+        });
+        server.listen(0, '127.0.0.1', () => {
+          const { port } = server.address() as { port: number };
+          cleanups.push(() => new Promise((r) => server.close(() => r())));
+          resolve({ origin: `http://127.0.0.1:${port}` });
+        });
+      });
+      await handleAttachmentTool(client, 'create_attachment', {
+        ownerId: 'n1',
+        role: 'image',
+        content: `${origin}/remote.png`,
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ mime: 'image/png', title: 'remote.png' })
+      );
+      const sent = (client.updateAttachmentContentBinary as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+      expect(sent.equals(PNG_BYTES)).toBe(true);
+    });
+
+    it('no longer requires mime or title in the tool schema', () => {
+      const tools = registerAttachmentTools();
+      const create = tools.find((t) => t.name === 'create_attachment')!;
+      const required = (create.inputSchema as { required?: string[] }).required ?? [];
+      expect(required).not.toContain('mime');
+      expect(required).not.toContain('title');
+      expect(required).toContain('content');
+    });
+  });
+
+  describe('write_attachment replace', () => {
+    it('accepts a file path, keeping the stored mime', async () => {
+      const path = await makePng();
+      (client.getAttachment as ReturnType<typeof vi.fn>).mockResolvedValue({
+        attachmentId: 'a1',
+        mime: 'image/png',
+        title: 'old.png',
+      });
+      await handleAttachmentTool(client, 'write_attachment', {
+        attachmentId: 'a1',
+        mode: 'replace',
+        content: path,
+      });
+      const sent = (client.updateAttachmentContentBinary as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+      expect(sent.equals(PNG_BYTES)).toBe(true);
+    });
+  });
+
+  describe('create_note images[] / files[]', () => {
+    it('accepts an image entry that is just a path — mime and filename inferred', async () => {
+      const path = await makePng('diagram.png');
+      const result = await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'With image',
+        type: 'text',
+        content: '<p>hello</p>',
+        images: [{ data: path }],
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'image', mime: 'image/png', title: 'diagram.png' })
+      );
+      const sent = (client.updateAttachmentContentBinary as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+      expect(sent.equals(PNG_BYTES)).toBe(true);
+      expect(result).not.toBeNull();
+    });
+
+    it('still accepts the legacy base64 + mime + filename entry shape', async () => {
+      await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'Legacy',
+        type: 'text',
+        content: '<p><img src="image:0"></p>',
+        images: [{ data: PNG_BYTES.toString('base64'), mime: 'image/png', filename: 'x.png' }],
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ mime: 'image/png', title: 'x.png' })
+      );
+    });
+
+    it('defaults a filename when the entry has neither filename nor a source name', async () => {
+      await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'Unnamed',
+        type: 'text',
+        content: '<p>hi</p>',
+        images: [{ data: PNG_BYTES.toString('base64'), mime: 'image/png' }],
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'image-0.png' })
+      );
+    });
+
+    it('reads a text file entry from a path into a one-step attachment', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'trilium-mcp-handler-'));
+      cleanups.push(() => rm(dir, { recursive: true, force: true }));
+      const path = join(dir, 'data.csv');
+      await writeFile(path, 'a,b\n1,2\n');
+      await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'With file',
+        type: 'text',
+        content: '<p>hi</p>',
+        files: [{ data: path }],
+      });
+      expect(client.createAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: 'file',
+          mime: 'text/csv',
+          title: 'data.csv',
+          content: 'a,b\n1,2\n',
+        })
+      );
+      expect(client.updateAttachmentContentBinary).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('create_note binary content', () => {
+    it('uploads exact bytes and is immune to markdown conversion mangling', async () => {
+      const payload = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0x2a]);
+      await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'A PDF',
+        type: 'file',
+        mime: 'application/pdf',
+        content: payload.toString('base64'),
+        format: 'markdown',
+      });
+      const sent = (client.updateNoteContentBinary as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+      expect(sent.equals(payload)).toBe(true);
+    });
+
+    it('accepts a file path as binary note content', async () => {
+      const path = await makePng();
+      await handleNoteTool(client, 'create_note', {
+        parentNoteId: 'root',
+        title: 'A PNG note',
+        type: 'image',
+        mime: 'image/png',
+        content: path,
+      });
+      const sent = (client.updateNoteContentBinary as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+      expect(sent.equals(PNG_BYTES)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Every content-carrying tool input — `create_attachment.content`, `write_attachment` replace `content`, the `data` field of `images[]`/`files[]` entries, and binary note `content` — now accepts **any** of these forms, auto-detected by a new shared normalizer (`src/tools/contentInput.ts`):

| Form | Example |
|---|---|
| Local file path | `/tmp/screenshots/shot.png`, `~/docs/report.pdf` |
| `file://` path (forces path interpretation) | `file:///tmp/shot.png` |
| http(s) URL (server fetches it) | `https://example.com/logo.png` |
| Data URL | `data:image/png;base64,...` |
| Inline base64 / raw text | unchanged, backward compatible |

`mime`, `filename`, and `create_attachment.title` are now **optional** — resolved via data-URL header > explicit mime > magic-byte sniff (`file-type`, already a dep) > SVG heuristic > HTTP Content-Type > extension map, with path/URL basenames as default titles. The simplest call is now `{ownerId, role: "image", content: "/tmp/screenshot.png"}` — the LLM never re-encodes bytes it already has on disk through its own context window.

## Detection safety

Path detection is **verification-gated**: a string only counts as a path when it is ≤1024 chars **and** `stat()` finds a regular file — so JPEG base64 (starts `/9j/`) and prose can never be misread. Undetectable inline input with no mime returns an actionable error rather than a guess. Text-note body content is untouched (a note *about* `/etc/hosts` stays verbatim).

## Security

- Local path reads: **on for stdio** (operator's own machine), **off for `--transport http`** where a path would read the server's filesystem on behalf of a tenant. `--allow-local-file-read` / `--no-local-file-read` override; optional `--local-file-roots` sandbox (realpath-checked, symlinks can't escape).
- URL fetches reuse the existing SSRF guard (`assertUrlIsSafe`), re-run on **every redirect hop**, with `redirect: 'manual'`, a 30 s timeout, Content-Length pre-check plus a streamed byte-counter cap (`--max-content-fetch-bytes`, default 50 MB), and a separate `--content-url-allowlist` knob (kept apart from `urlAllowlist`, which governs tenant Trilium hosts).
- Log redaction already covers the new forms (`content`/`data` are BLOB_KEYS); locked in with a test.

## Bug fixes along the way

- **Silent base64 corruption**: `Buffer.from(x, 'base64')` skips invalid chars, so typos became corrupted uploads. Now strictly validated → `INVALID_BASE64` with a suggestion.
- **Markdown mangling of binary notes**: `create_note` with a binary mime + `format: "markdown"` ran markdown conversion over the base64 payload *before* decoding. Binary content is now normalized before any conversion.
- Collapsed three duplicated data-URL/mime resolution code paths (notes.ts + 2× attachments.ts) into the one normalizer.

## Out of scope (by design)

- No image compression/resizing — Trilium's server-side compression settings handle that; original bytes are uploaded untouched.
- `manage_system` import (base64 ZIP) unchanged; can adopt the normalizer later as a one-liner.

## Testing

- `tests/unit/contentInput.test.ts`: 47-case matrix — detection precedence, ambiguity traps (JPEG `/9j/` base64, prose that decodes as base64), mime resolution order, `localFileRoots` symlink escape, redirect-to-blocked-host, chunked-download cap, `~/` expansion.
- Handler-level tests: path/URL/optional-mime flows for `create_attachment`, `write_attachment` replace, `images[]`/`files[]`, binary `create_note`; tool-schema assertions; logger redaction.
- 4 new integration tests against a real Trilium instance proving **byte-identical round trips** from disk, `~/` paths, and a fixture HTTP server, with sniffed mimes (README examples mirror these tests).
- Full suites green: 628 unit / 161 integration, lint + prettier + tsc clean.